### PR TITLE
media: append form field "media[]" instead of "media"

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -53,7 +53,7 @@ Media.prototype.addFile = function(files, fn){
   // process formData
   files = Array.isArray(files) ? files : [ files ];
   for (var i = 0; i < files.length; i++) {
-    params.formData.push(['media', files[i]]);
+    params.formData.push([ 'media[]', files[i] ]);
   }
 
   this.wpcom.sendRequest(params, null, null, fn);


### PR DESCRIPTION
Before this was returning nothing:

```
{ media: [] }
```

But now it's returning... _something_ (though still not usable
data, but that shouldn't be wpcom.js' fault at this point).

```
{ media:
   [ { id: '0',
       date: '-0001-11-30T00:00:00+00:00',
       parent: 0,
       link: false,
       title: '',
       caption: '',
       description: '',
       metadata: false,
       meta: [Object] } ] }
```

**Note:** using a test script similar to:

``` js
var fs = require('fs');
var WPCOM = require('wpcom');

// add your proper `token` here
var token;
var wpcom = WPCOM(token);

// the file to upload
var filepath = process.argv[2] || '/Users/nrajlich/Desktop/dir with pics/12546_10151204990307839_1126555884_n.jpeg';
var rs = fs.createReadStream(filepath);

wpcom.site('tootallnate.wordpress.com').addMediaFile(rs, function (err, data) {
  if (err) {
    console.log(Object.keys(err));
    throw err;
  }
  console.error(data);
  console.error('DONE!');
});
```
