### PR TITLE
test: remove WPCOM test

### DIFF
--- a/test/test.index.js
+++ b/test/test.index.js
@@ -21,11 +21,6 @@ describe('WPCOM', function(){
 
   describe('sync', function(){
 
-    it('should create a WPCOM object', function(){
-      var wpcom = new WPCOM();
-      assert.ok(wpcom instanceof WPCOM);
-    });
-
     it('should set the token', function(){
       var wpcom = new WPCOM(test.site.private.token);
       assert.equal('string', typeof wpcom.token);


### PR DESCRIPTION
Constructor method doesn't return `WPCOM` instance anymore.

https://github.com/Automattic/wpcom.js/blob/master/index.js#L22
