### PR TITLE
test: remove token test

### DIFF
--- a/test/test.index.js
+++ b/test/test.index.js
@@ -19,16 +19,6 @@ var util = require('./util');
 
 describe('WPCOM', function(){
 
-  describe('sync', function(){
-
-    it('should set the token', function(){
-      var wpcom = new WPCOM(test.site.private.token);
-      assert.equal('string', typeof wpcom.token);
-      assert.equal(test.site.private.token, wpcom.token);
-    });
-
-  });
-
   describe('async', function(){
 
     describe('freshlyPressed()', function(){


### PR DESCRIPTION
`token` property isn't presente anymore in `WPCOM` instance. 
