### PR TITLE
Restore previously removed methods to keep backwards compatability

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ var inherits = require('inherits');
  * @param {String} [token] - OAuth API access token
  * @public
  */
+
 function XhrWPCOM(token) {
   if (!(this instanceof WPCOM)) return new WPCOM(token);
   WPCOM.call(this, request);
@@ -34,6 +35,7 @@ inherits(XhrWPCOM, WPCOM);
  * @param {String} token - API token to use for requests
  * @public
  */
+
 XhrWPCOM.prototype.setToken = function(token) {
   this.token = token;
 };
@@ -44,6 +46,7 @@ XhrWPCOM.prototype.setToken = function(token) {
  *
  * @api private
  */
+
 XhrWPCOM.prototype.sendRequest = function (params, query, body, fn) {
   if ('string' == typeof params) params = { path: params };
   // token

--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
-
 /**
  * Module dependencies.
  */
 
 var WPCOM = require('./wpcom');
 var request = require('wpcom-xhr-request');
+var inherits = require('inherits');
 
 /**
+ * WordPress.com REST API class.
+ *
  * XMLHttpRequest (and CORS) API access method.
  *
  * API authentication is done via an (optional) access `token`,
@@ -18,10 +20,36 @@ var request = require('wpcom-xhr-request');
  * @param {String} [token] - OAuth API access token
  * @public
  */
+function XhrWPCOM(token) {
+  if (!(this instanceof WPCOM)) return new WPCOM(token);
+  WPCOM.call(this, request);
+  this.token = token;
+}
 
-module.exports = function(token){
-  return new WPCOM(function(params, fn){
-    params.authToken = token;
-    return request(params, fn);
-  });
+inherits(XhrWPCOM, WPCOM);
+
+/**
+ * Set access token.
+ *
+ * @param {String} token - API token to use for requests
+ * @public
+ */
+XhrWPCOM.prototype.setToken = function(token) {
+  this.token = token;
 };
+
+/**
+ * Overwrite the parent `sendRequest()` function so that we can
+ * add the `authToken` to every API request if it's present.
+ *
+ * @api private
+ */
+XhrWPCOM.prototype.sendRequest = function (params, query, body, fn) {
+  if ('string' == typeof params) params = { path: params };
+  // token
+  var token = params.token || this.token;
+  if (token) params.authToken = token;
+  return WPCOM.prototype.sendRequest.call(this, params, query, body, fn);
+};
+
+module.exports = XhrWPCOM;

--- a/index.js
+++ b/index.js
@@ -28,6 +28,10 @@ function XhrWPCOM(token){
   this.token = token;
 }
 
+/**
+ * Mixin `WPCOM`
+ */
+
 inherits(XhrWPCOM, WPCOM);
 
 /**
@@ -49,7 +53,10 @@ XhrWPCOM.prototype.setToken = function(token){
  */
 
 XhrWPCOM.prototype.sendRequest = function(params, query, body, fn) {
-  if ('string' == typeof params) params = { path: params };
+  if ('string' == typeof params) {
+    params = { path: params };
+  }
+
   // token
   var token = params.token || this.token;
   if (token) params.authToken = token;

--- a/index.js
+++ b/index.js
@@ -21,8 +21,9 @@ var inherits = require('inherits');
  * @public
  */
 
-function XhrWPCOM(token) {
+function XhrWPCOM(token){
   if (!(this instanceof WPCOM)) return new WPCOM(token);
+
   WPCOM.call(this, request);
   this.token = token;
 }
@@ -36,7 +37,7 @@ inherits(XhrWPCOM, WPCOM);
  * @public
  */
 
-XhrWPCOM.prototype.setToken = function(token) {
+XhrWPCOM.prototype.setToken = function(token){
   this.token = token;
 };
 
@@ -47,7 +48,7 @@ XhrWPCOM.prototype.setToken = function(token) {
  * @api private
  */
 
-XhrWPCOM.prototype.sendRequest = function (params, query, body, fn) {
+XhrWPCOM.prototype.sendRequest = function(params, query, body, fn) {
   if ('string' == typeof params) params = { path: params };
   // token
   var token = params.token || this.token;

--- a/index.js
+++ b/index.js
@@ -7,6 +7,12 @@ var request = require('wpcom-xhr-request');
 var inherits = require('inherits');
 
 /**
+ * Export `XhrWPCOM`
+ */
+
+module.exports = XhrWPCOM;
+
+/**
  * WordPress.com REST API class.
  *
  * XMLHttpRequest (and CORS) API access method.
@@ -62,5 +68,3 @@ XhrWPCOM.prototype.sendRequest = function(params, query, body, fn) {
   if (token) params.authToken = token;
   return WPCOM.prototype.sendRequest.call(this, params, query, body, fn);
 };
-
-module.exports = XhrWPCOM;


### PR DESCRIPTION
The purpose of this PR is to allow us to include the reorganization from #64 in a minor version release. In a 3.0 release we might look into getting rid of these extra methods since they would be better off in the `request` object being passed in to `WPCOM`.