### PR TITLE
URIencode the site id in order to use Jetpack sites installed on subfolders.

### DIFF
--- a/lib/site.js
+++ b/lib/site.js
@@ -49,7 +49,7 @@ function Site(id, wpcom) {
   this.wpcom = wpcom;
 
   debug('set %o site id', id);
-  this._id = id;
+  this._id = encodeURIComponent(id);
 }
 
 /**


### PR DESCRIPTION
cc @retrofox 
