### PR TITLE
Fix site.statsVideo

### DIFF
--- a/lib/site.js
+++ b/lib/site.js
@@ -340,7 +340,7 @@ Site.prototype.statsReferrersSpamDelete = function (domain, fn) {
 Site.prototype.statsVideo = function (videoId, fn) {
   var path = '/sites/' + this._id + '/stats/video/' + videoId;
 
-  return this.wpcom.req.get(path, query, fn);
+  return this.wpcom.req.get(path, fn);
 };
 
 /**

--- a/test/test.wpcom.site.js
+++ b/test/test.wpcom.site.js
@@ -570,4 +570,20 @@ describe('wpcom.site', function () {
     });
   });
 
+  describe('wpcom.site.statsVideo', function() {
+    it('should request video stats', function (done) {
+      site.statsVideo( testing_post.ID, function(err, data) {
+        if (err) throw err;
+
+        assert.ok(data);
+        assert(data.fields instanceof Array);
+        assert(data.data instanceof Array);
+        assert(data.pages instanceof Array);
+
+        done();
+      });
+    });
+  });
+
+
 });


### PR DESCRIPTION
In #89 I failed to add a test for the `site.statsVideo` method, and ironically there was a bug with that method.  I have fixed the error and added a test to cover this endpoint as well.