### PR TITLE
Fix jsdoc etc. to support static+runtime analysis

### DIFF
--- a/lib/category.js
+++ b/lib/category.js
@@ -16,7 +16,7 @@ var debug = require('debug')('wpcom:category');
 
 function Category(slug, sid, wpcom) {
   if (!sid) {
-    throw new Error('`side id` is not correctly defined');
+    throw new Error('`site id` is not correctly defined');
   }
 
   if (!(this instanceof Category)) {

--- a/lib/comment.js
+++ b/lib/comment.js
@@ -18,7 +18,7 @@ var debug = require('debug')('wpcom:comment');
 
 function Comment(cid, pid, sid, wpcom) {
   if (!sid) {
-    throw new Error('`side id` is not correctly defined');
+    throw new Error('`site id` is not correctly defined');
   }
 
   if (!(this instanceof Comment)) {

--- a/lib/commentlike.js
+++ b/lib/commentlike.js
@@ -54,9 +54,9 @@ CommentLike.prototype.mine = function (query, fn) {
  * @api public
  */
 
-CommentLike.prototype.add = function (query, body, fn) {
+CommentLike.prototype.add = function (query, fn) {
   var path = '/sites/' + this._sid + '/comments/' + this._cid + '/likes/new';
-  return this.wpcom.req.post(path, query, body, fn);
+  return this.wpcom.req.post(path, query, fn);
 };
 
 /**

--- a/lib/commentlike.js
+++ b/lib/commentlike.js
@@ -62,6 +62,7 @@ CommentLike.prototype.add = function (query, body, fn) {
 /**
  * Remove your Like from a Comment
  *
+ * @param {Object} [query]
  * @param {Function} fn
  * @api public
  */

--- a/lib/commentlike.js
+++ b/lib/commentlike.js
@@ -16,7 +16,7 @@ var debug = require('debug')('wpcom:commentlike');
 
 function CommentLike(cid, sid, wpcom) {
   if (!sid) {
-    throw new Error('`side id` is not correctly defined');
+    throw new Error('`site id` is not correctly defined');
   }
 
   if (!cid) {

--- a/lib/follow.js
+++ b/lib/follow.js
@@ -32,6 +32,7 @@ function Follow(site_id, wpcom) {
  *
  * @param {Object} [query]
  * @param {Function} fn
+ * @api public
  */
 
 Follow.prototype.state =
@@ -45,6 +46,7 @@ Follow.prototype.mine = function (query, fn) {
  *
  * @param {Object} [query]
  * @param {Function} fn
+ * @api public
  */
 
 Follow.prototype.follow =
@@ -58,6 +60,7 @@ Follow.prototype.add = function (query, fn) {
  *
  * @param {Object} [query]
  * @param {Function} fn
+ * @api public
  */
 
 Follow.prototype.unfollow =

--- a/lib/like.js
+++ b/lib/like.js
@@ -62,6 +62,7 @@ Like.prototype.add = function (query, fn) {
 /**
  * Remove your Like from a Post
  *
+ * @param {Object} [query]
  * @param {Function} fn
  * @api public
  */

--- a/lib/like.js
+++ b/lib/like.js
@@ -16,7 +16,7 @@ var debug = require('debug')('wpcom:like');
 
 function Like(pid, sid, wpcom) {
   if (!sid) {
-    throw new Error('`side id` is not correctly defined');
+    throw new Error('`site id` is not correctly defined');
   }
 
   if (!pid) {

--- a/lib/post.js
+++ b/lib/post.js
@@ -228,8 +228,7 @@ Post.prototype.comment = function (cid) {
 
 Post.prototype.comments = function (query, fn) {
   var comment = new Comment(null, this._id, this._sid, this.wpcom);
-  comment.replies(query, fn);
-  return comment;
+  return comment.replies(query, fn);
 };
 
 /**

--- a/lib/post.js
+++ b/lib/post.js
@@ -38,6 +38,7 @@ function Post(id, sid, wpcom) {
 /**
  * Set post `id`
  *
+ * @param {String} id
  * @api public
  */
 

--- a/lib/post.js
+++ b/lib/post.js
@@ -222,7 +222,7 @@ Post.prototype.comment = function (cid) {
  * Return recent comments
  *
  * @param {Object} [query]
- * @param {String} id
+ * @param {Function} fn
  * @api public
  */
 

--- a/lib/post.js
+++ b/lib/post.js
@@ -177,7 +177,6 @@ Post.prototype.likesList = function (query, fn) {
 /**
  * Search within a site for related posts
  *
- * @param {Object} [query]
  * @param {Object} body
  * @param {Function} fn
  * @api public
@@ -185,7 +184,7 @@ Post.prototype.likesList = function (query, fn) {
 
 Post.prototype.related = function (body, fn) {
   var path = '/sites/' + this._sid + '/posts/' + this._id + '/related';
-  return this.wpcom.req.put(path, query, null, fn);
+  return this.wpcom.req.put(path, body, null, fn);
 };
 
 /**

--- a/lib/post.js
+++ b/lib/post.js
@@ -222,7 +222,7 @@ Post.prototype.comment = function (cid) {
 /**
  * Return recent comments
  *
- * @param {Objecy} [query]
+ * @param {Object} [query]
  * @param {String} id
  * @api public
  */

--- a/lib/reblog.js
+++ b/lib/reblog.js
@@ -16,7 +16,7 @@ var debug = require('debug')('wpcom:reblog');
 
 function Reblog(pid, sid, wpcom) {
   if (!sid) {
-    throw new Error('`side id` is not correctly defined');
+    throw new Error('`site id` is not correctly defined');
   }
 
   if (!pid) {

--- a/lib/site.js
+++ b/lib/site.js
@@ -85,17 +85,19 @@ Site.prototype.get = function (query, fn) {
 function list(subpath) {
 
   /**
-   * Return the <names>List method
+   * Create and return the <names>List method
    *
    * @param {Object} [query]
    * @param {Function} fn
    * @api public
    */
 
-  return function (query, fn) {
+  var listMethod = function (query, fn) {
     var path = '/sites/' + this._id + '/' + subpath;
     return this.wpcom.req.get(path, query, fn);
   };
+  listMethod._publicAPI = true;
+  return listMethod;
 }
 
 // walk for each resource and create related method

--- a/lib/site.js
+++ b/lib/site.js
@@ -254,6 +254,7 @@ Site.prototype.tag = function (slug) {
  *
  * @param {String} url
  * @param {Object} [query]
+ * @param {Function} fn
  * @api public
  */
 
@@ -282,6 +283,7 @@ Site.prototype.renderShortcode = function (url, query, fn) {
  *
  * @param {String} url
  * @param {Object} [query]
+ * @param {Function} fn
  * @api public
  */
 
@@ -306,6 +308,7 @@ Site.prototype.renderEmbed = function (url, query, fn) {
  * Mark a referrering domain as spam
  *
  * @param {String} domain
+ * @param {Function} fn
  * @api public
  */
 
@@ -320,6 +323,7 @@ Site.prototype.statsReferrersSpamNew = function (domain, fn) {
  * Remove referrering domain from spam
  *
  * @param {String} domain
+ * @param {Function} fn
  * @api public
  */
 
@@ -334,6 +338,7 @@ Site.prototype.statsReferrersSpamDelete = function (domain, fn) {
  * Get detailed stats about a VideoPress video
  *
  * @param {String} videoId
+ * @param {Function} fn
  * @api public
  */
 
@@ -347,6 +352,7 @@ Site.prototype.statsVideo = function (videoId, fn) {
  * Get detailed stats about a particular post
  *
  * @param {String} postId
+ * @param {Function} fn
  * @api public
  */
 

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -16,7 +16,7 @@ var debug = require('debug')('wpcom:tag');
 
 function Tag(slug, sid, wpcom) {
   if (!sid) {
-    throw new Error('`side id` is not correctly defined');
+    throw new Error('`site id` is not correctly defined');
   }
 
   if (!(this instanceof Tag)) {


### PR DESCRIPTION
For Team I/O's current meetup project we're beefing up the developer site, including generating sample API requests.  I'm doing some static+runtime analysis of wpcom.js to auto-generate the code for these requests.  These are jsdoc and other changes needed to support that work.