### PR TITLE
Rearrange alias order

### DIFF
--- a/lib/comment.js
+++ b/lib/comment.js
@@ -131,8 +131,8 @@ Comment.prototype.reply = function (query, body, fn) {
  * @api public
  */
 
-Comment.prototype['delete'] =
-Comment.prototype.del = function (query, fn) {
+Comment.prototype.del =
+Comment.prototype['delete'] = function (query, fn) {
   var path = '/sites/' + this._sid + '/comments/' + this._cid + '/delete';
   return this.wpcom.req.del(path, query, fn);
 };

--- a/lib/commentlike.js
+++ b/lib/commentlike.js
@@ -40,8 +40,8 @@ function CommentLike(cid, sid, wpcom) {
  * @api public
  */
 
-CommentLike.prototype.state =
-CommentLike.prototype.mine = function (query, fn) {
+CommentLike.prototype.mine =
+CommentLike.prototype.state = function (query, fn) {
   var path = '/sites/' + this._sid + '/comments/' + this._cid + '/likes/mine';
   return this.wpcom.req.get(path, query, fn);
 };
@@ -67,8 +67,8 @@ CommentLike.prototype.add = function (query, fn) {
  * @api public
  */
 
-CommentLike.prototype['delete'] =
-CommentLike.prototype.del = function (query, fn) {
+CommentLike.prototype.del =
+CommentLike.prototype['delete'] = function (query, fn) {
   var path = '/sites/' + this._sid + '/comments/' + this._cid + '/likes/mine/delete';
   return this.wpcom.req.del(path, query, fn);
 };

--- a/lib/follow.js
+++ b/lib/follow.js
@@ -35,8 +35,8 @@ function Follow(site_id, wpcom) {
  * @api public
  */
 
-Follow.prototype.state =
-Follow.prototype.mine = function (query, fn) {
+Follow.prototype.mine =
+Follow.prototype.state = function (query, fn) {
   var path = '/sites/' + this._sid + '/follows/mine';
   return this.wpcom.req.get(path, query, fn);
 };

--- a/lib/like.js
+++ b/lib/like.js
@@ -40,8 +40,8 @@ function Like(pid, sid, wpcom) {
  * @api public
  */
 
-Like.prototype.state =
-Like.prototype.mine = function (query, fn) {
+Like.prototype.mine =
+Like.prototype.state = function (query, fn) {
   var path = '/sites/' + this._sid + '/posts/' + this._pid + '/likes/mine';
   return this.wpcom.req.get(path, query, fn);
 };
@@ -67,8 +67,8 @@ Like.prototype.add = function (query, fn) {
  * @api public
  */
 
-Like.prototype['delete'] =
-Like.prototype.del = function (query, fn) {
+Like.prototype.del =
+Like.prototype['delete'] = function (query, fn) {
   var path = '/sites/' + this._sid + '/posts/' + this._pid + '/likes/mine/delete';
   return this.wpcom.req.del(path, query, fn);
 };

--- a/lib/post.js
+++ b/lib/post.js
@@ -142,8 +142,8 @@ Post.prototype.update = function (query, body, fn) {
  * @api public
  */
 
-Post.prototype['delete'] =
-Post.prototype.del = function (query, fn) {
+Post.prototype.del =
+Post.prototype['delete'] = function (query, fn) {
   var path = '/sites/' + this._sid + '/posts/' + this._id + '/delete';
   return this.wpcom.req.del(path, query, fn);
 };

--- a/lib/reblog.js
+++ b/lib/reblog.js
@@ -40,8 +40,8 @@ function Reblog(pid, sid, wpcom) {
  * @api public
  */
 
-Reblog.prototype.state =
-Reblog.prototype.mine = function (query, fn) {
+Reblog.prototype.mine =
+Reblog.prototype.state = function (query, fn) {
   var path = '/sites/' + this._sid + '/posts/' + this._pid + '/reblogs/mine';
   return this.wpcom.req.get(path, query, fn);
 };

--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -44,8 +44,8 @@ Req.prototype.get = function (params, query, fn) {
  * @api public
  */
 
-Req.prototype.put =
-Req.prototype.post = function (params, query, body, fn) {
+Req.prototype.post =
+Req.prototype.put = function (params, query, body, fn) {
   if ('function' === typeof body) {
     fn = body;
     body = query;


### PR DESCRIPTION
There is no change in behavior due to this commit, but it will have a
few benefits for auto-generated code samples:

- Show `.del()` instead of `.delete()` (to avoid potential problems with
  `delete` keyword)
- Show `.mine()` instead of `.state()` (since the endpoints are named
  with `/mine` in the path)
- Show `.post()` instead of `.put()` (if one day we do examples for
  the `this.wpcom.req` methods)