### PR TITLE
Site: Allow Query Options on statsVideo and statsPostViews

### DIFF
--- a/docs/site.md
+++ b/docs/site.md
@@ -177,7 +177,7 @@ site.statsFollowers( function(err, data){
 });
 ```
 
-### Site#statsPostViews(postId, fn)
+### Site#statsPostViews(postId,[query, ]fn)
 
 Returns stats for a certain [post](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/post/%24post_id/).
 
@@ -277,7 +277,7 @@ site.statsTopAuthors( function(err, data){
 });
 ```
 
-### Site#statsVideo(videoId, fn)
+### Site#statsVideo(videoId,[query, ]fn)
 
 Returns stats about a particular VideoPress [video](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/video/%24post_id/).
 

--- a/lib/site.js
+++ b/lib/site.js
@@ -340,6 +340,7 @@ Site.prototype.statsReferrersSpamDelete = function (domain, fn) {
  * Get detailed stats about a VideoPress video
  *
  * @param {String} videoId
+ * @param {Object} [query]
  * @param {Function} fn
  * @api public
  */
@@ -352,13 +353,14 @@ Site.prototype.statsVideo = function (videoId, query, fn) {
     query = {};
   }
 
-  return this.wpcom.req.get(path, fn);
+  return this.wpcom.req.get(path, query, fn);
 };
 
 /**
  * Get detailed stats about a particular post
  *
  * @param {String} postId
+ * @param {Object} [query]
  * @param {Function} fn
  * @api public
  */
@@ -371,7 +373,7 @@ Site.prototype.statsPostViews = function (postId, query, fn) {
     query = {};
   }
 
-  return this.wpcom.req.get(path, fn);
+  return this.wpcom.req.get(path, query, fn);
 };
 
 /**

--- a/lib/site.js
+++ b/lib/site.js
@@ -344,8 +344,13 @@ Site.prototype.statsReferrersSpamDelete = function (domain, fn) {
  * @api public
  */
 
-Site.prototype.statsVideo = function (videoId, fn) {
+Site.prototype.statsVideo = function (videoId, query, fn) {
   var path = '/sites/' + this._id + '/stats/video/' + videoId;
+
+  if ('function' == typeof query) {
+    fn = query;
+    query = {};
+  }
 
   return this.wpcom.req.get(path, fn);
 };
@@ -358,8 +363,13 @@ Site.prototype.statsVideo = function (videoId, fn) {
  * @api public
  */
 
-Site.prototype.statsPostViews = function (postId, fn) {
+Site.prototype.statsPostViews = function (postId, query, fn) {
   var path = '/sites/' + this._id + '/stats/post/' + postId;
+
+  if ('function' == typeof query) {
+    fn = query;
+    query = {};
+  }
 
   return this.wpcom.req.get(path, fn);
 };


### PR DESCRIPTION
The current `statsPostViews` and `statsVideo` methods don't allow for passing in additional query options.  This PR adds in the query option as an optional attribute.  This would allow one call to `statsPostViews` on calypso to not use an undocumented implementation.