### PR TITLE
Docs: change wpcom.sites() to wpcom.site()

### DIFF
--- a/docs/comment.md
+++ b/docs/comment.md
@@ -19,7 +19,7 @@ Return a single Comment
 
 ```js
 wpcom
-.sites('blog.wordpress.com')
+.site('blog.wordpress.com')
 .comment(32)
 .get(function(err, data){
   // comment `data` object
@@ -32,7 +32,7 @@ Return recent comments for a post
 
 ```js
 wpcom
-.sites('blog.wordpress.com')
+.site('blog.wordpress.com')
 .post(342)
 .comment()
 .replies(function(err, data){
@@ -45,7 +45,7 @@ Create a comment on a post
 
 ```js
 wpcom
-.sites('blog.wordpress.com')
+.site('blog.wordpress.com')
 .post(342)
 .comment()
 .add('Nice blog post !!!', function(err, data){
@@ -58,7 +58,7 @@ Edit a comment
 
 ```js
 wpcom
-.sites('blog.wordpress.com')
+.site('blog.wordpress.com')
 .comment(123)
 .update('It is not a blog post !!!', function(err, data){
 });
@@ -70,7 +70,7 @@ Create a Comment as a reply to another Comment
 
 ```js
 wpcom
-.sites('blog.wordpress.com')
+.site('blog.wordpress.com')
 .comment(123)
 .reply('Im sorry, I've edited the previous comment', function(err, data){
 });
@@ -82,7 +82,7 @@ Delete a comment
 
 ```js
 wpcom
-.sites('blog.wordpress.com')
+.site('blog.wordpress.com')
 .comment(123)
 .del(function(err, data){
 });

--- a/docs/follow.md
+++ b/docs/follow.md
@@ -22,7 +22,7 @@ Follow the current blog
 
 ```js
 wpcom
-.sites('blog.wordpress.com')
+.site('blog.wordpress.com')
 .follow()
 .add(function(err, data){
 	// response handler
@@ -39,7 +39,7 @@ Unfollow the current blog
 
 ```js
 wpcom
-.sites('blog.wordpress.com')
+.site('blog.wordpress.com')
 .follow()
 .del(function(err, data){
 	// respnose handler
@@ -56,7 +56,7 @@ Get your Follow status for a Site
 
 ```js
 wpcom
-.sites('blog.wordpress.com')
+.site('blog.wordpress.com')
 .follow()
 .mine(function(error, data){
   // mine status

--- a/docs/like.md
+++ b/docs/like.md
@@ -23,7 +23,7 @@ Get your Like status for a Post
 
 ```js
 wpcom
-.sites('blog.wordpress.com')
+.site('blog.wordpress.com')
 .post(342)
 .like()
 .mine(function(err, data){
@@ -37,7 +37,7 @@ Like the post
 
 ```js
 wpcom
-.sites('blog.wordpress.com')
+.site('blog.wordpress.com')
 .post(342)
 .like()
 .add(function(err, data){
@@ -51,7 +51,7 @@ Remove your existing Like from the post
 
 ```js
 wpcom
-.sites('blog.wordpress.com')
+.site('blog.wordpress.com')
 .post(342)
 .like()
 .del(function(err, data){

--- a/docs/post.md
+++ b/docs/post.md
@@ -8,7 +8,7 @@
 ```js
 var wpcom = require('wpcom')('<your-token>');
 var post = wpcom
-           .sites('blog.wordpress.com')
+           .site('blog.wordpress.com')
            .post(342);
 });
 ```
@@ -79,7 +79,7 @@ Get post likes list
 
 ```js
 wpcom
-.sites('blog.wordpress.com')
+.site('blog.wordpress.com')
 .post(342)
 .likesList(function(err, list){
   // like `list` object
@@ -92,7 +92,7 @@ Create and return a new `Like` instance.
 More info in [Like doc page](./like.md).
 
 ```js
-var like = wpcom.sites('blog.wordpress.com').post(342).like();
+var like = wpcom.site('blog.wordpress.com').post(342).like();
 ```
 
 ### Post#reblog()
@@ -101,7 +101,7 @@ Create and return a new `Reblog` instance.
 More info in [Reblog doc page](./reblog.md).
 
 ```js
-var reblog = wpcom.sites('blog.wordpress.com').post(342).reblog();
+var reblog = wpcom.site('blog.wordpress.com').post(342).reblog();
 ```
 
 ### Post#comment()
@@ -115,7 +115,7 @@ Recent recent comments
 
 ```js
 wpcom
-.sites('blog.wordpress.com')
+.site('blog.wordpress.com')
 .post(342)
 .comments(function(err, list){
   // post comments list

--- a/docs/reblog.md
+++ b/docs/reblog.md
@@ -23,7 +23,7 @@ Get your reblog status for the Post
 
 ```js
 wpcom
-.sites('blog.wordpress.com')
+.site('blog.wordpress.com')
 .post(342)
 .reblog()
 .mine(function(err, data){
@@ -42,7 +42,7 @@ var body = {
 };
 
 wpcom
-.sites('blog.wordpress.com')
+.site('blog.wordpress.com')
 .post(342)
 .reblog()
 .add(body, function(err, data){
@@ -56,7 +56,7 @@ It's almost a `Reblog#mine` alias.
 
 ```js
 wpcom
-.sites('blog.wordpress.com')
+.site('blog.wordpress.com')
 .post(342)
 .reblog()
 .to(456, 'Really nice a blog post !', function(err, data){


### PR DESCRIPTION
A number of the docs pages use this syntax:

`wpcom.sites('blog.wordpress.com')`

...but attempting to use this results in <code>Uncaught TypeError: wpcom.sites is not a function</code>.

Looking at the tests and the [docs for the site handler itself](https://github.com/Automattic/wpcom.js/blob/master/docs/site.md), it looks like the syntax should actually be:

`wpcom.site('blog.wordpress.com')`

I've changed all instances of this in the docs.