### PR TITLE
Use PHP style query params for a batch request

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -3,6 +3,7 @@
  * Module dependencies.
  */
 
+var qs = require('qs');
 var debug = require('debug')('wpcom:batch');
 
 /**
@@ -19,7 +20,7 @@ function Batch(wpcom) {
 
   this.wpcom = wpcom;
 
-  this.urls = [];
+  this.urls = '';
 }
 
 /**
@@ -30,7 +31,7 @@ function Batch(wpcom) {
  */
 
 Batch.prototype.add = function (url) {
-  this.urls.push(url);
+  this.urls += encodeURIComponent('urls[]') + '=' + encodeURIComponent(url) + '&';
   return this;
 };
 
@@ -49,15 +50,7 @@ Batch.prototype.run = function (query, fn) {
     query = {};
   }
 
-  var querystr = [];
-
-  for (var x = 0; x < this.urls.length; x++) {
-      querystr.push(encodeURIComponent( 'urls[]' ) + '=' + encodeURIComponent( this.urls[x] ));
-  }
-
-  query.querystr = querystr.join('&');
-
-  return this.wpcom.req.get('/batch', query, fn);
+  return this.wpcom.req.get('/batch', this.urls + qs.stringify(query), fn);
 };
 
 /**

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -48,7 +48,14 @@ Batch.prototype.run = function (query, fn) {
     fn = query;
     query = {};
   }
-  query['urls[]'] = this.urls;
+
+  var querystr = [];
+
+  for (var x = 0; x < this.urls.length; x++) {
+      querystr.push(encodeURIComponent( 'urls[]' ) + '=' + encodeURIComponent( this.urls[x] ));
+  }
+
+  query.querystr = querystr.join('&');
 
   return this.wpcom.req.get('/batch', query, fn);
 };

--- a/lib/util/send-request.js
+++ b/lib/util/send-request.js
@@ -41,10 +41,7 @@ module.exports = function (params, query, body, fn) {
   query = query || {};
 
   // pass `query` and/or `body` to request params
-  if (query.querystr)
-    params.query = query.querystr;
-  else
-    params.query = query;
+  params.query = query;
 
   // Handle special query parameters
   // - `apiVersion`

--- a/lib/util/send-request.js
+++ b/lib/util/send-request.js
@@ -41,7 +41,10 @@ module.exports = function (params, query, body, fn) {
   query = query || {};
 
   // pass `query` and/or `body` to request params
-  params.query = query;
+  if (query.querystr)
+    params.query = query.querystr;
+  else
+    params.query = query;
 
   // Handle special query parameters
   // - `apiVersion`

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "debug": "~2.1.0",
+    "qs": "^4.0.0",
     "wpcom-xhr-request": "0.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The wpcom API expects batched requests to be of the form:

`urls[]=/first&urls[]=/second`

The current wpcom.js is sending it as:

`urls[]=/first,/second`

When the current wpcom.js is sending this over `wpcom-proxy-request` the problem disappears as `wpcom-proxy-request` uses `jQuery.param()` to convert the parameters, and this encodes them in PHP-style. When sent with `wpcom-xhr-request` it doesn't get converted

This PR manually encodes the query string and passes it to send-request as a string rather than an object. It fixes `wpcom-xhr-request` and doesn't seem to have any effect on `wpcom-proxy-request`.

I'm unaware of the greater context of this change so feel free to modify as needed.

Added:

I think this is related to this:

https://github.com/visionmedia/superagent/issues/670

The `wpcom.js` batch unit test passes, but when the same request is made from a browser the request URL is different and fails. My patch may not be needed if superagent handles it
