### PR TITLE
adds the page templates endpoint and test

### DIFF
--- a/lib/site.js
+++ b/lib/site.js
@@ -377,6 +377,18 @@ Site.prototype.statsPostViews = function (postId, query, fn) {
 };
 
 /**
+ * Get available page templates for a site
+ *
+ * @param {Function} fn
+ * @api public
+ */
+
+Site.prototype.pageTemplates = function (fn) {
+  var path = '/sites/' + this._id + '/page-templates';
+  return this.wpcom.req.get(path, fn);
+};
+
+/**
  * Expose `Site` module
  */
 

--- a/lib/site.js
+++ b/lib/site.js
@@ -24,6 +24,7 @@ var resources = [
   'posts',
   'shortcodes',
   'embeds',
+  [ 'pageTemplates', 'page-templates' ],
   [ 'stats', 'stats' ],
   [ 'statsClicks', 'stats/clicks' ],
   [ 'statsComments', 'stats/comments' ],
@@ -374,18 +375,6 @@ Site.prototype.statsPostViews = function (postId, query, fn) {
   }
 
   return this.wpcom.req.get(path, query, fn);
-};
-
-/**
- * Get available page templates for a site
- *
- * @param {Function} fn
- * @api public
- */
-
-Site.prototype.pageTemplates = function (fn) {
-  var path = '/sites/' + this._id + '/page-templates';
-  return this.wpcom.req.get(path, fn);
 };
 
 /**

--- a/test/test.wpcom.site.js
+++ b/test/test.wpcom.site.js
@@ -428,7 +428,7 @@ describe('wpcom.site', function () {
       });
     });
   });
- 
+
   describe('wpcom.site.get', function () {
     it('should require site data', function (done) {
       site.get(function (err, data) {
@@ -445,7 +445,7 @@ describe('wpcom.site', function () {
     it('should create a new blog post', function (done) {
       site.addPost(fixture.post, function (err, data) {
         if (err) throw err;
-        
+
         // store in post ID global var
         new_post_ID = data.ID;
 
@@ -551,6 +551,18 @@ describe('wpcom.site', function () {
         assert(data.fields instanceof Array);
         assert(data.data instanceof Array);
         assert(data.pages instanceof Array);
+        done();
+      });
+    });
+  });
+
+  describe('wpcom.site.pageTemplates', function() {
+    it('should request page templates', function (done) {
+      site.pageTemplates( function(err, data) {
+        if (err) throw err;
+
+        assert.ok(data);
+        assert(data.templates instanceof Array);
         done();
       });
     });


### PR DESCRIPTION
Hey @retrofox, this adds a newly-documented endpoint to retrieve all possible `page-templates` for a given site. `page-templates` are dictated by the active theme for a site. Not all themes will have `page-templates` available, but then it should return an empty array.