### PR TITLE
Make tests depend on node_modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ example-browser-cors: all
 	cd examples/browser-cors/; $(NPM) install
 	$(NODE) examples/browser-cors/index.js
 
-test:
+test: node_modules
 	@$(MOCHA) \
 		--timeout 60s \
 		--slow 3s \
@@ -45,7 +45,7 @@ test:
 		--bail \
 		--reporter spec
 
-test-all:
+test-all: node_modules
 	@$(MOCHA) \
 		--timeout 60s \
 		--slow 3s \


### PR DESCRIPTION
Previously, if you ran the following sequence it failed:

```bash
make clean
make test-all
```

This patch adjusts the `Makefile` to build the node modules if they don't exist when running the tests.