### PR TITLE
Set default Promise return in absence of callback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ example-browser-cors: all
 test: node_modules
 	@$(MOCHA) \
 		--compilers js:babel/register \
-		--timeout 60s \
+		--timeout 120s \
 		--slow 3s \
 		--grep "$(filter-out $@,$(MAKECMDGOALS))" \
 		--bail \
@@ -49,7 +49,7 @@ test: node_modules
 test-all: node_modules
 	@$(MOCHA) \
 		--compilers js:babel/register \
-		--timeout 60s \
+		--timeout 120s \
 		--slow 3s \
 		--bail \
 		--reporter spec

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -42,7 +42,7 @@ Batch.prototype.add = function (url) {
  * @api public
  */
 
-Batch.prototype.run = function (query, fn) {
+Batch.prototype.run = function (query={}, fn) {
   if ('function' === typeof query) {
     fn = query;
     query = {};

--- a/lib/comment.js
+++ b/lib/comment.js
@@ -67,10 +67,15 @@ Comment.prototype.replies = function (query, fn) {
  */
 
 Comment.prototype.add = function (query, body, fn) {
-  if ('function' === typeof body) {
-    fn = body;
-    body = query;
-    query = {};
+  if ( undefined === fn ) {
+    if ( undefined === body ) {
+      body = query;
+      query = {};
+    } else if ( 'function' === typeof body ) {
+      fn = body;
+      body = query;
+      query = {};
+    }
   }
 
   body = 'string' === typeof body ? { content: body } : body;
@@ -116,7 +121,7 @@ Comment.prototype.reply = function (query, body, fn) {
     body = query;
     query = {};
   }
-  
+
   body = 'string' === typeof body ? { content: body } : body;
 
   var path = '/sites/' + this._sid + '/comments/' + this._cid + '/replies/new';

--- a/lib/media.js
+++ b/lib/media.js
@@ -1,4 +1,4 @@
-  
+
 /**
  * Module dependencies.
  */
@@ -73,10 +73,15 @@ Media.prototype.update = function (query, body, fn) {
  */
 
 Media.prototype.addFiles = function (query, files, fn) {
-  if ('function' === typeof files) {
-    fn = files;
-    files = query;
-    query = {};
+  if ( undefined === fn ) {
+    if ( undefined === files ) {
+      files = query;
+      query = {};
+    } else if ( 'function' === typeof files ) {
+      fn = files;
+      files = query;
+      query = {};
+    }
   }
 
   var params = {
@@ -127,10 +132,15 @@ Media.prototype.addFiles = function (query, files, fn) {
  */
 
 Media.prototype.addUrls = function (query, media, fn) {
-  if ('function' === typeof media) {
-    fn = media;
-    media = query;
-    query = {};
+  if ( undefined === fn ) {
+    if ( undefined === media ) {
+      media = query;
+      query = {};
+    } else if ( 'function' === typeof media ) {
+      fn = media;
+      media = query;
+      query = {};
+    }
   }
 
   var path = '/sites/' + this._sid + '/media/new';

--- a/lib/post.js
+++ b/lib/post.js
@@ -97,27 +97,41 @@ Post.prototype.getBySlug = function (query, fn) {
  */
 
 Post.prototype.add = function (query, body, fn) {
-  if ('function' === typeof body) {
-    fn = body;
-    body = query;
-    query = {};
+  if ( undefined === fn ) {
+    if ( undefined === body ) {
+      body = query;
+      query = {};
+    } else if ( 'function' === typeof body ) {
+      fn = body;
+      body = query;
+      query = {};
+    }
   }
 
   var path = '/sites/' + this._sid + '/posts/new';
-  return this.wpcom.req.post(path, query, body, function (err, data) {
-    if (err) {
-      return fn(err);
-    }
 
-    // update POST object
-    this._id = data.ID;
-    debug('Set post _id: %s', this._id);
+  return this.wpcom.req.post(path, query, body)
+    .then(data => {
+      // update POST object
+      this._id = data.ID;
+      debug('Set post _id: %s', this._id);
 
-    this._slug = data.slug;
-    debug('Set post _slug: %s', this._slug);
+      this._slug = data.slug;
+      debug('Set post _slug: %s', this._slug);
 
-    fn(null, data)
-  }.bind(this));
+      if ( 'function' === typeof fn ) {
+        fn(null, data);
+      } else {
+        return new Promise(resolve => resolve(data));
+      }
+    })
+    .catch(err => {
+      if ( 'function' === typeof fn ) {
+        fn(err);
+      } else {
+        return new Promise( ( resolve, reject ) => reject(error) );
+      }
+    });
 };
 
 /**

--- a/lib/post.js
+++ b/lib/post.js
@@ -122,14 +122,14 @@ Post.prototype.add = function (query, body, fn) {
       if ( 'function' === typeof fn ) {
         fn(null, data);
       } else {
-        return new Promise(resolve => resolve(data));
+        return Promise.resolve( data );
       }
     })
     .catch(err => {
       if ( 'function' === typeof fn ) {
         fn(err);
       } else {
-        return new Promise( ( resolve, reject ) => reject(error) );
+        return Promise.reject( error );
       }
     });
 };

--- a/lib/reblog.js
+++ b/lib/reblog.js
@@ -81,12 +81,16 @@ Reblog.prototype.add = function (query, body, fn) {
  */
 
 Reblog.prototype.to = function (dest, note, fn) {
-  if ('function' === typeof note) {
-    fn = note;
-    note = null;
+  if ( undefined === fn ) {
+    if ( undefined === note ) {
+      note = null;
+    } else if ('function' === typeof note) {
+      fn = note;
+      note = null;
+    }
   }
 
-  this.add({ note: note, destination_site_id: dest }, fn);
+  return this.add({ note: note, destination_site_id: dest }, fn);
 };
 
 /**

--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -30,7 +30,7 @@ Req.prototype.get = function (params, query, fn) {
     fn = query;
     query = {};
   }
-  
+
   return sendRequest.call(this.wpcom, params, query, null, fn);
 };
 
@@ -46,10 +46,15 @@ Req.prototype.get = function (params, query, fn) {
 
 Req.prototype.post =
 Req.prototype.put = function (params, query, body, fn) {
-  if ('function' === typeof body) {
-    fn = body;
-    body = query;
-    query = {};
+  if (undefined === fn) {
+    if (undefined === body) {
+      body = query;
+      query = {}
+    } else if ( 'function' === typeof body) {
+      fn = body;
+      body = query;
+      query = {};
+    }
   }
 
   // params can be a string

--- a/lib/util/send-request.js
+++ b/lib/util/send-request.js
@@ -18,7 +18,7 @@ var debug_res = require('debug')('wpcom:send-request:res');
  */
 
 module.exports = function (params, query, body, fn) {
-  // `params` can be just the path (String)  
+  // `params` can be just the path (String)
   params = 'string' === typeof params ? { path : params } : params;
 
   debug('sendRequest(%o)', params.path);
@@ -67,16 +67,22 @@ module.exports = function (params, query, body, fn) {
   if (body) {
     params.body = body;
   }
+  debug('params: %o', params);
 
-  // callback `fn` function is optional
-  if (!fn) {
-    fn = function (err) { if (err) { throw err; } };
+  // if callback is provided, behave traditionally
+  if ('function' === typeof fn) {
+    // request method
+    return this.request(params, function(err, res) {
+      debug_res(res);
+      fn(err, res);
+    });
   }
 
-  debug('params: %o', params);
-  // request method
-  return this.request(params, function(err, res) {
-    debug_res(res);
-    fn(err, res);
-  });
+  // but if not, return a Promise
+  return new Promise((resolve, reject) => {
+    this.request(params, (err, res) => {
+      debug_res(res);
+      err ? reject(err) : resolve(res);
+    });
+  } );
 };

--- a/test/test.apiVersion.js
+++ b/test/test.apiVersion.js
@@ -21,28 +21,18 @@ describe('apiVersion', function() {
   var wpcom = util.wpcom();
   var site = wpcom.site(util.site());
 
-  it('should request changing api version', function(done) {
-    site
-    .addMediaUrls({ apiVersion: '1.1' }, fixture.media.urls[1],
-    function(err, data){
-      if (err) throw err;
-
-      assert.ok(data);
-
-      site
-      .mediaList({ apiVersion: '1' }, function(err, data) {
-        if (err) throw err;
-
-        site
-        .addMediaFiles({ apiVersion: '1.1' }, fixture.media.files[0],
-        function(err, data) {
-          if (err) throw err;
-
-          assert.ok(data);
-          done();
-        });
-      });
-    });
+  it('should request changing api version', done => {
+    site.addMediaUrls({ apiVersion: '1.1' }, fixture.media.urls[1])
+      .then( data => {
+        assert.ok(data);
+        return site.mediaList({ apiVersion: '1' } )
+      })
+      .then( data => site.addMediaFiles({ apiVersion: '1.1' }, fixture.media.files[0]))
+      .then( data => {
+        assert.ok(data);
+        done();
+      })
+      .catch( done );
   });
 
 });

--- a/test/test.util.req.js
+++ b/test/test.util.req.js
@@ -29,12 +29,13 @@ describe('wpcom', function(){
       it('should get 400 error code', function(done){
 
         var path = '/sites/' + site._id + '/posts/new';
-        wpcom.req.post(path, function(err, data){
-          assert.ok(err);
-          assert.equal(400, err.statusCode);
-          done();
-        });
-
+        wpcom.req.post(path)
+          .then(() => done('No error returned'))
+          .catch(err=>{
+            assert.ok(err);
+            assert.equal(400, err.statusCode);
+            done();
+          });
       });
     });
 
@@ -42,14 +43,13 @@ describe('wpcom', function(){
       it('should create a new post', function(done){
 
         var path = '/sites/' + site._id + '/posts/new';
-        wpcom.req.post(path, null, fixture.post, function(err, data){
-          if (err) throw err;
-
-          testing_post = data;
-          assert.ok(data);
-          done();
-        });
-
+        wpcom.req.post(path, null, fixture.post)
+          .then( data => {
+            testing_post = data;
+            assert.ok(data);
+            done();
+          })
+          .catch(done);
       });
     });
 
@@ -58,13 +58,12 @@ describe('wpcom', function(){
   describe('wpcom.util.req.del', function(){
     it('should delete added post', function(done){
       var path = '/sites/' + site._id + '/posts/' + testing_post.ID + '/delete';
-      wpcom.req.post(path,  function(err, data){
-        if (err) throw err;
-
-        assert.ok(data.ID, testing_post.ID);
-        done();
-      });
-
+      wpcom.req.post(path)
+        .then(data => {
+          assert.ok(data.ID, testing_post.ID);
+          done();
+        })
+        .catch(done);
     });
   });
 

--- a/test/test.wpcom.batch.js
+++ b/test/test.wpcom.batch.js
@@ -26,18 +26,14 @@ describe('wpcom.batch', function() {
     var url_posts = '/sites/' + site._id + '/posts';
     var url_me = '/me';
 
-    batch
-    .add(url_site)
-    .add(url_posts)
-    .add(url_me)
-    .run(function(err, data) {
-      if (err) throw err;
-
-      assert.ok(data);
-      assert.ok(data[url_site]);
-      assert.ok(data[url_posts]);
-      assert.ok(data[url_me]);
-      done();
-    });
+    batch.add(url_site).add(url_posts).add(url_me).run()
+      .then(data => {
+        assert.ok(data);
+        assert.ok(data[url_site]);
+        assert.ok(data[url_posts]);
+        assert.ok(data[url_me]);
+        done();
+      })
+      .catch( done );
   });
 });

--- a/test/test.wpcom.js
+++ b/test/test.wpcom.js
@@ -16,15 +16,15 @@ describe('wpcom', function(){
     it('should require freshly pressed', function(done){
       var wpcom = util.wpcom_public();
 
-      wpcom.freshlyPressed(function(err, data){
-        if (err) throw err;
-
-        // testing object
-        assert.ok(data);
-        assert.equal('number', typeof data.number);
-        assert.ok(data.posts instanceof Array);
-        done();
-      });
+      wpcom.freshlyPressed()
+        .then( data => {
+          // testing object
+          assert.ok(data);
+          assert.equal('number', typeof data.number);
+          assert.ok(data.posts instanceof Array);
+          done();
+        })
+        .catch(done);
     });
   });
 

--- a/test/test.wpcom.me.js
+++ b/test/test.wpcom.me.js
@@ -22,83 +22,82 @@ describe('wpcom.me', function(){
   var me = wpcom.me();
 
   describe('wpcom.me.get', function(){
-    it('should require user information object', function(done){
-      me.get(function(err, me){
-        if (err) throw err;
+    it('should require user information object', done => {
+      me.get()
+        .then(me => {
+          // testing object
+          assert.ok(me);
+          assert.equal('object', typeof me);
 
-        // testing object
-        assert.ok(me);
-        assert.equal('object', typeof me);
+          // testing user data
+          assert.equal('number', typeof me.ID);
 
-        // testing user data
-        assert.equal('number', typeof me.ID);
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
 
-    it('should require user passing query parameter', function(done){
-      me.get({ context: 'info' }, function(err, me){
-        if (err) throw err;
+    it('should require user passing query parameter', done => {
+      me.get({ context: 'info' })
+        .then(me => {
+          // testing object
+          assert.ok(me);
+          assert.equal('object', typeof me);
 
-        // testing object
-        assert.ok(me);
-        assert.equal('object', typeof me);
+          // testing user data
+          assert.equal('number', typeof me.ID);
 
-        // testing user data
-        assert.equal('number', typeof me.ID);
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.me.sites', function(){
-    it('should require user sites object', function(done){
-      me.sites(function(err, sites){
-        if (err) throw err;
-        done();
-      });
+    it('should require user sites object', done => {
+      me.sites()
+        .then(() => done())
+        .catch(done);
     });
   });
 
   describe('wpcom.me.likes', function(){
-    it('should require user likes', function(done){
-      me.likes(function(err, data){
-        if (err) throw err;
+    it('should require user likes', done => {
+      me.likes()
+        .then(data => {
+          assert.equal('number', typeof data.found);
+          assert.equal('object', typeof data.likes);
+          assert.ok(data.likes instanceof Array);
 
-        assert.equal('number', typeof data.found);
-        assert.equal('object', typeof data.likes);
-        assert.ok(data.likes instanceof Array);
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.me.groups', function(){
-    it('should require groups', function(done){
-      me.groups(function(err, data){
-        if (err) throw err;
+    it('should require groups', done => {
+      me.groups()
+        .then(data => {
+          assert.equal('object', typeof data.groups);
+          assert.ok(data.groups instanceof Array);
 
-        assert.equal('object', typeof data.groups);
-        assert.ok(data.groups instanceof Array);
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.me.connections', function(){
-    it('should require third-party connections', function(done){
-      me.connections(function(err, data){
-        if (err) throw err;
+    it('should require third-party connections', done => {
+      me.connections()
+        .then(data => {
+          assert.equal('object', typeof data.connections);
+          assert.ok(data.connections instanceof Array);
 
-        assert.equal('object', typeof data.connections);
-        assert.ok(data.connections instanceof Array);
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 

--- a/test/test.wpcom.site.category.js
+++ b/test/test.wpcom.site.category.js
@@ -16,98 +16,92 @@ describe('wpcom.site.category', function() {
   // Global instances
   var wpcom = util.wpcom();
   var site = wpcom.site(util.site());
-  var new_category;
 
   // Create a testing_category before to start tests
   var testing_category;
-  before(function(done){
+  before(done => {
     fixture.category.name += Math.random() * 1000000 | 0;
-    site.category()
-    .add(fixture.category, function(err, category) {
-      if (err) throw err;
 
-      testing_category = category;
-      done();
-    });
+    site.category().add(fixture.category)
+      .then( category => {
+        testing_category = category;
+        done();
+      })
+      .catch(done);
   });
 
   // Delete testing category
-  after(function(done){
-    site.category(testing_category.slug)
-    .delete(function(err, category) {
-      if (err) throw err;
-
-      done();
-    });
+  after(done => {
+    site.category(testing_category.slug).delete()
+      .then(() => done())
+      .catch(done);
   });
 
-  
-  describe('wpcom.site.category.get', function(){
-    it('should get added category', function(done){
-      site.category(testing_category.slug)
-      .get(function(err, data){
-        if (err) throw err;
 
-        assert.ok(data);
-        assert.ok(data instanceof Object, 'data is not an object');
-        assert.equal(testing_category.slug, data.slug);
-        assert.equal(testing_category.name, data.name);
-        done();
-      });
+  describe('wpcom.site.category.get', function(){
+    it('should get added category', done => {
+      site.category(testing_category.slug).get()
+        .then(data => {
+          assert.ok(data);
+          assert.ok(data instanceof Object, 'data is not an object');
+          assert.equal(testing_category.slug, data.slug);
+          assert.equal(testing_category.name, data.name);
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.category.add', function(){
-    it('should add a new category', function(done){
+    it('should add a new category', done => {
       var category = site.category();
 
       fixture.category.name += '-added';
-      category.add(fixture.category, function(err, data){
-        if (err) throw err;
+      category.add(fixture.category)
+        .then(data => {
+          // checking some data date
+          assert.ok(data);
+          assert.ok(data instanceof Object, 'data is not an object');
 
-        // checking some data date
-        assert.ok(data);
-        assert.ok(data instanceof Object, 'data is not an object');
+          // store added catogory
+          new_category = data;
 
-        // store added catogory
-        new_category = data;
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.category.update', function(){
-    it('should edit the new added category', function(done){
+    it('should edit the new added category', done => {
       var category = site.category(new_category.slug);
       var edited_name = fixture.category.name + '-updated';
 
-      category.update({ name: edited_name }, function(err, data){
-        if (err) throw err;
+      category.update({ name: edited_name })
+        .then(data => {
+          assert.ok(data);
+          assert.equal(edited_name, data.name);
 
-        assert.ok(data);
-        assert.equal(edited_name, data.name);
+          // update added category
+          new_category = data;
 
-        // update added category
-        new_category = data;
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.category.delete', function(){
-    it('should delete the new added category', function(done){
-      site.category(new_category.slug)
-      .delete(function(err, data){
-        if (err) throw err;
+    it('should delete the new added category', done => {
+      site.category(new_category.slug).delete()
+        .then(data => {
+          assert.ok(data);
+          assert.equal('true', data.success);
+          assert.equal(new_category.slug, data.slug);
 
-        assert.ok(data);
-        assert.equal('true', data.success);
-        assert.equal(new_category.slug, data.slug);
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 

--- a/test/test.wpcom.site.embeds.js
+++ b/test/test.wpcom.site.embeds.js
@@ -22,15 +22,15 @@ describe('wpcom.site.embeds', function () {
   var site = wpcom.site(util.site());
 
   describe('wpcom.site.renderEmbed(\'embed\')', function () {
-    it('should render embed', function(done){
+    it('should render embed', done => {
 
-      site.renderEmbed(fixture.embed, function (err, data) {
-        if (err) throw err;
-
-        assert.equal(data.embed_url, fixture.embed);
-        assert.ok(data.result);
-        done();
-      });
+      site.renderEmbed(fixture.embed)
+        .then( data => {
+          assert.equal(data.embed_url, fixture.embed);
+          assert.ok(data.result);
+          done();
+        })
+        .catch(done);
     });
   });
 

--- a/test/test.wpcom.site.follow.js
+++ b/test/test.wpcom.site.follow.js
@@ -23,41 +23,41 @@ describe('wpcom.site.follow', function(){
   var follow = site.follow();
 
   describe('wpcom.site.follow.follow', function(){
-    it('should follow site', function(done){
-      follow.follow(function(err, data){
-        if (err) throw err;
+    it('should follow site', done => {
+      follow.follow()
+        .then(data => {
+          assert.ok(data);
+          assert.equal(true, data.is_following);
 
-        assert.ok(data);
-        assert.equal(true, data.is_following);
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.follow.unfollow', function(){
-    it('should unfollow site', function(done){
-      follow.unfollow(function(err, data){
-        if (err) throw err;
+    it('should unfollow site', done => {
+      follow.unfollow()
+        .then(data => {
+          assert.ok(data);
+          assert.equal(false, data.is_following);
 
-        assert.ok(data);
-        assert.equal(false, data.is_following);
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.follow.mine', function() {
-    it('should get follow status', function(done){
-      follow.mine(function(err, data){
-        if (err) throw err;
+    it('should get follow status', done => {
+      follow.mine()
+        .then(data => {
+          assert.ok(data);
+          assert.equal(false, data.is_following);
 
-        assert.ok(data);
-        assert.equal(false, data.is_following);
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 

--- a/test/test.wpcom.site.js
+++ b/test/test.wpcom.site.js
@@ -16,7 +16,7 @@ var fixture = require('./fixture');
  * Create a `Site` instance
  */
 
-describe('wpcom.siter', function () {
+describe('wpcom.site', function () {
   // Global instances
   var wpcom = util.wpcom();
   var site = wpcom.site(util.site());

--- a/test/test.wpcom.site.js
+++ b/test/test.wpcom.site.js
@@ -16,7 +16,7 @@ var fixture = require('./fixture');
  * Create a `Site` instance
  */
 
-describe('wpcom.site', function () {
+describe('wpcom.siter', function () {
   // Global instances
   var wpcom = util.wpcom();
   var site = wpcom.site(util.site());
@@ -25,546 +25,543 @@ describe('wpcom.site', function () {
   var site_ID;
 
   // Create a testing_post before to start tests
-  before(function (done) {
-    site.addPost(fixture.post, function (err, data_post) {
-      if (err) return done(err);
+  before(done => {
+    site.addPost(fixture.post)
+      .then( data_post => {
+        testing_post = data_post;
 
-      testing_post = data_post;
-
-      site.get(function (err, data_site) {
-        if (err) return done(err);
-
+        return site.get();
+      })
+      .then( data_site => {
         site_ID = data_site.ID;
 
         done();
-      });
-    });
+      })
+      .catch(done);
   });
 
   // Delete testing post
-  after(function (done) {
-    site.deletePost(testing_post.ID, function (err, data) {
-      if (err) throw err;
-
-      done();
-    });
+  after(done => {
+    site.deletePost(testing_post.ID)
+      .then(() => done())
+      .catch(done);
   });
 
   describe('wpcom.site.lists', function () {
 
     describe('wpcom.site.postsList', function () {
-      it('should request posts list', function (done) {
-        site.postsList(function (err, list) {
-          if (err) throw err;
+      it('should request posts list', done => {
+        site.postsList()
+          .then( list => {
+            // list object data testing
+            assert.equal('object', typeof list);
 
-          // list object data testing
-          assert.equal('object', typeof list);
+            // `posts list` object data testing
+            assert.equal('number', typeof list.found);
 
-          // `posts list` object data testing
-          assert.equal('number', typeof list.found);
+            assert.equal('object', typeof list.posts);
+            assert.ok(list.posts instanceof Array);
 
-          assert.equal('object', typeof list.posts);
-          assert.ok(list.posts instanceof Array);
-
-          done();
-        });
+            done();
+          })
+          .catch(done);
       });
 
-      it('should request only one post', function (done) {
-        site.postsList({ number: 1 }, function (err, list) {
-          if (err) throw err;
-
-          // list object data testing
-          assert.equal('object', typeof list);
-          assert.equal('number', typeof list.found);
-          assert.equal('object', typeof list.posts);
-          assert.ok(list.posts instanceof Array);
-          assert.ok(list.posts.length <= 1);
-          done();
-        });
+      it('should request only one post', done => {
+        site.postsList({ number: 1 })
+          .then( list => {
+            // list object data testing
+            assert.equal('object', typeof list);
+            assert.equal('number', typeof list.found);
+            assert.equal('object', typeof list.posts);
+            assert.ok(list.posts instanceof Array);
+            assert.ok(list.posts.length <= 1);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.mediaList', function () {
-      it('should request media library list', function (done) {
-        site.mediaList(function (err, list) {
-          if (err) throw err;
-
-          // list object data testing
-          assert.equal('object', typeof list);
-          assert.equal('number', typeof list.found);
-          assert.equal('object', typeof list.media);
-          assert.ok(list.media instanceof Array);
-          done();
-        });
+      it('should request media library list', done => {
+        site.mediaList()
+          .then( list => {
+            // list object data testing
+            assert.equal('object', typeof list);
+            assert.equal('number', typeof list.found);
+            assert.equal('object', typeof list.media);
+            assert.ok(list.media instanceof Array);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.usersList', function () {
-      it('should request users list', function (done) {
-        site.usersList(function (err, list) {
-          if (err) throw err;
-
-          assert.equal('number', typeof list.found);
-          assert.ok(list.users instanceof Array);
-          done();
-        });
+      it('should request users list', done => {
+        site.usersList()
+          .then( list => {
+            assert.equal('number', typeof list.found);
+            assert.ok(list.users instanceof Array);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.commentsList', function () {
-      it('should request comments list', function (done) {
-        site.commentsList(function (err, list){
-          if (err) throw err;
-
-          // list object data testing
-          assert.equal('object', typeof list);
-          assert.equal('number', typeof list.found);
-          assert.equal('object', typeof list.comments);
-          assert.ok(list.comments instanceof Array);
-          done();
-        });
+      it('should request comments list', done => {
+        site.commentsList()
+          .then( list => {
+            // list object data testing
+            assert.equal('object', typeof list);
+            assert.equal('number', typeof list.found);
+            assert.equal('object', typeof list.comments);
+            assert.ok(list.comments instanceof Array);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.followsList', function () {
-      it('should request follows list', function (done) {
-        site.followsList(function (err, list) {
-          if (err) throw err;
-
-          // list object data testing
-          assert.equal('object', typeof list);
-          assert.equal('number', typeof list.found);
-          assert.equal('object', typeof list.users);
-          assert.ok(list.users instanceof Array);
-          done();
-        });
+      it('should request follows list', done => {
+        site.followsList()
+          .then( list => {
+            // list object data testing
+            assert.equal('object', typeof list);
+            assert.equal('number', typeof list.found);
+            assert.equal('object', typeof list.users);
+            assert.ok(list.users instanceof Array);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.categoriesList', function () {
-      it('should request categories list', function (done) {
-        site.categoriesList(function (err, list) {
-          if (err) throw err;
-
-          // list object data testing
-          assert.equal('object', typeof list);
-          assert.equal('number', typeof list.found);
-          assert.equal('object', typeof list.categories);
-          assert.ok(list.categories instanceof Array);
-          done();
-        });
+      it('should request categories list', done => {
+        site.categoriesList()
+          .then( list => {
+            // list object data testing
+            assert.equal('object', typeof list);
+            assert.equal('number', typeof list.found);
+            assert.equal('object', typeof list.categories);
+            assert.ok(list.categories instanceof Array);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.shortcodesList', function () {
-      it('should request shortcodes list', function (done) {
-        site.shortcodesList(function (err, list) {
-          if (err) throw err;
-
-          // list object data testing
-          assert.equal('object', typeof list);
-          assert.equal('object', typeof list.shortcodes);
-          assert.ok(list.shortcodes instanceof Array);
-          done();
-        });
+      it('should request shortcodes list', done => {
+        site.shortcodesList()
+          .then( list => {
+            // list object data testing
+            assert.equal('object', typeof list);
+            assert.equal('object', typeof list.shortcodes);
+            assert.ok(list.shortcodes instanceof Array);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.embedsList', function () {
-      it('should request embeds list', function (done) {
-        site.embedsList(function (err, list) {
-          if (err) throw err;
-
-          // list object data testing
-          assert.equal('object', typeof list);
-          assert.equal('object', typeof list.embeds);
-          assert.ok(list.embeds instanceof Array);
-          done();
-        });
+      it('should request embeds list', done => {
+        site.embedsList()
+          .then( list => {
+            // list object data testing
+            assert.equal('object', typeof list);
+            assert.equal('object', typeof list.embeds);
+            assert.ok(list.embeds instanceof Array);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.tagsList', function () {
-      it('should request tags list', function (done) {
-        site.tagsList(function (err, list) {
-          if (err) throw err;
-
-          // list object data testing
-          assert.equal('object', typeof list);
-          assert.equal('number', typeof list.found);
-          assert.equal('object', typeof list.tags);
-          assert.ok(list.tags instanceof Array);
-          done();
-        });
+      it('should request tags list', done => {
+        site.tagsList()
+          .then( list => {
+            // list object data testing
+            assert.equal('object', typeof list);
+            assert.equal('number', typeof list.found);
+            assert.equal('object', typeof list.tags);
+            assert.ok(list.tags instanceof Array);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.stats', function () {
-      it('should request stats data', function (done) {
-        site.stats(function (err, data) {
-          if (err) throw err;
+      it('should request stats data', done => {
+        site.stats()
+          .then( data => {
+            assert.equal('string', typeof Date(data.day));
+            assert.equal('object', typeof data.stats);
+            assert.ok(data.stats instanceof Object);
 
-          assert.equal('string', typeof Date(data.day));
-          assert.equal('object', typeof data.stats);
-          assert.ok(data.stats instanceof Object);
-
-          assert.equal('object', typeof data.visits);
-          assert.ok(data.visits instanceof Object);
-          done();
-        });
+            assert.equal('object', typeof data.visits);
+            assert.ok(data.visits instanceof Object);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.statsComments', function () {
-      it('should request comments data', function (done) {
-        site.statsComments(function (err, data) {
-          if (err) throw err;
+      it('should request comments data', done => {
+        site.statsComments()
+          .then( data => {
+            assert.equal('string', typeof Date(data.day));
+            assert.ok(data.authors instanceof Array);
+            assert.ok(data.posts instanceof Array);
 
-          assert.equal('string', typeof Date(data.day));
-          assert.ok(data.authors instanceof Array);
-          assert.ok(data.posts instanceof Array);
-
-          assert.equal('number', typeof data.monthly_comments);
-          assert.equal('number', typeof data.total_comments);
-          assert.equal('string', typeof data.most_active_day);
-          assert.equal('string', typeof data.most_active_time);
-          done();
-        });
+            assert.equal('number', typeof data.monthly_comments);
+            assert.equal('number', typeof data.total_comments);
+            assert.equal('string', typeof data.most_active_day);
+            assert.equal('string', typeof data.most_active_time);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.statsCommentFollowers', function () {
-      it('should request comment follower data', function (done) {
-        site.statsCommentFollowers(function (err, data) {
-          if (err) throw err;
-
-          assert.equal('string', typeof Date(data.day));
-          assert.ok(data.posts instanceof Array);
-          assert.equal('number', typeof data.page);
-          assert.equal('number', typeof data.pages);
-          assert.equal('number', typeof data.total);
-          done();
-        });
+      it('should request comment follower data', done => {
+        site.statsCommentFollowers()
+          .then( data => {
+            assert.equal('string', typeof Date(data.day));
+            assert.ok(data.posts instanceof Array);
+            assert.equal('number', typeof data.page);
+            assert.equal('number', typeof data.pages);
+            assert.equal('number', typeof data.total);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.statsFollowers', function () {
-      it('should request follower data', function (done) {
-        site.statsFollowers(function (err, data) {
-          if (err) throw err;
-
-          assert.equal('string', typeof Date(data.day));
-          assert.ok(data.subscribers instanceof Array);
-          assert.equal('number', typeof data.page);
-          assert.equal('number', typeof data.pages);
-          assert.equal('number', typeof data.total);
-          assert.equal('number', typeof data.total_email);
-          assert.equal('number', typeof data.total_wpcom);
-          done();
-        });
+      it('should request follower data', done => {
+        site.statsFollowers()
+          .then( data => {
+            assert.equal('string', typeof Date(data.day));
+            assert.ok(data.subscribers instanceof Array);
+            assert.equal('number', typeof data.page);
+            assert.equal('number', typeof data.pages);
+            assert.equal('number', typeof data.total);
+            assert.equal('number', typeof data.total_email);
+            assert.equal('number', typeof data.total_wpcom);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.statsPublicize', function () {
-      it('should request publicize data', function (done) {
-        site.statsPublicize(function (err, data) {
-          if (err) throw err;
-
-          assert.equal('string', typeof Date(data.day));
-          assert.ok(data.services instanceof Array);
-          done();
-        });
+      it('should request publicize data', done => {
+        site.statsPublicize()
+          .then( data => {
+            assert.equal('string', typeof Date(data.day));
+            assert.ok(data.services instanceof Array);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.statsStreak', function () {
-      it('should request streak data', function (done) {
-        site.statsStreak(function (err, data) {
-          if (err) throw err;
-
-          assert.equal('string', typeof Date(data.day));
-          assert.ok(data.streak instanceof Object);
-          done();
-        });
+      it('should request streak data', done => {
+        site.statsStreak()
+          .then( data => {
+            assert.equal('string', typeof Date(data.day));
+            assert.ok(data.streak instanceof Object);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.statsSummary', function () {
-      it('should request summary data', function (done) {
-        site.statsSummary(function (err, data) {
-          if (err) throw err;
-
-          assert.equal('string', typeof Date(data.day));
-          assert.equal('string', typeof data.period);
-          assert.equal('number', typeof data.likes);
-          assert.equal('number', typeof data.views);
-          assert.equal('number', typeof data.visitors);
-          assert.equal('number', typeof data.comments);
-          assert.equal('number', typeof data.followers);
-          assert.equal('number', typeof data.reblogs);
-          done();
-        });
+      it('should request summary data', done => {
+        site.statsSummary()
+          .then( data => {
+            assert.equal('string', typeof Date(data.day));
+            assert.equal('string', typeof data.period);
+            assert.equal('number', typeof data.likes);
+            assert.equal('number', typeof data.views);
+            assert.equal('number', typeof data.visitors);
+            assert.equal('number', typeof data.comments);
+            assert.equal('number', typeof data.followers);
+            assert.equal('number', typeof data.reblogs);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.statsTags', function () {
-      it('should request tag data', function (done) {
-        site.statsTags(function (err, data) {
-          if (err) throw err;
-
-          assert.equal('string', typeof Date(data.day));
-          assert.ok(data.tags instanceof Array);
-          done();
-        });
+      it('should request tag data', done => {
+        site.statsTags()
+          .then( data => {
+            assert.equal('string', typeof Date(data.day));
+            assert.ok(data.tags instanceof Array);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.statsTopAuthors', function () {
-      it('should request author data', function (done) {
-        site.statsTopAuthors(function (err, data) {
-          if (err) throw err;
-
-          assert.equal('string', typeof Date(data.day));
-          assert.equal('string', typeof data.period);
-          assert.ok(data.days instanceof Object);
-          done();
-        });
+      it('should request author data', done => {
+        site.statsTopAuthors()
+          .then( data => {
+            assert.equal('string', typeof Date(data.day));
+            assert.equal('string', typeof data.period);
+            assert.ok(data.days instanceof Object);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.statsVideoPlays', function () {
-      it('should request video play data', function (done) {
-        site.statsVideoPlays(function (err, data) {
-          if (err) throw err;
-
-          assert.equal('string', typeof Date(data.day));
-          assert.equal('string', typeof data.period);
-          assert.ok(data.days instanceof Object);
-          done();
-        });
+      it('should request video play data', done => {
+        site.statsVideoPlays()
+          .then( data => {
+            assert.equal('string', typeof Date(data.day));
+            assert.equal('string', typeof data.period);
+            assert.ok(data.days instanceof Object);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.statsVisits', function () {
-      it('should request visits stats', function (done) {
-        site.statsVisits(function (err, data) {
-          if (err) throw err;
+      it('should request visits stats', done => {
+        site.statsVisits()
+          .then( data => {
+            assert.equal('string', typeof Date(data.unit));
 
-          assert.equal('string', typeof Date(data.unit));
+            assert.equal('object', typeof data.data);
+            assert.ok(data.data instanceof Array);
 
-          assert.equal('object', typeof data.data);
-          assert.ok(data.data instanceof Array);
-
-          assert.equal('object', typeof data.fields);
-          assert.ok(data.fields instanceof Array);
-          done();
-        });
+            assert.equal('object', typeof data.fields);
+            assert.ok(data.fields instanceof Array);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.statsReferrers', function () {
-      it('should request referrers stats', function (done) {
-        site.statsReferrers( function (err, data) {
-          if (err) throw err;
-
-          assert.equal('string', typeof Date(data.date));
-          assert.equal('object', typeof data.days);
-          assert.equal('string', typeof data.period);
-          done();
-        });
+      it('should request referrers stats', done => {
+        site.statsReferrers()
+          .then( data => {
+            assert.equal('string', typeof Date(data.date));
+            assert.equal('object', typeof data.days);
+            assert.equal('string', typeof data.period);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.statsTopPosts', function () {
-      it('should request top posts stats', function (done) {
-        site.statsTopPosts( function (err, data) {
-          if (err) throw err;
-
-          assert.equal('string', typeof Date(data.date));
-          assert.equal('object', typeof data.days);
-          assert.equal('string', typeof data.period);
-          done();
-        });
+      it('should request top posts stats', done => {
+        site.statsTopPosts()
+          .then( data => {
+            assert.equal('string', typeof Date(data.date));
+            assert.equal('object', typeof data.days);
+            assert.equal('string', typeof data.period);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.statsCountryViews', function () {
-      it('should request country views stats', function (done) {
-        site.statsCountryViews( function (err, data) {
-          if (err) throw err;
-
-          assert.equal('string', typeof Date(data.date));
-          assert.equal('object', typeof data.days);
-          assert.equal('object', typeof data['country-info']);
-          done();
-        });
+      it('should request country views stats', done => {
+        site.statsCountryViews()
+          .then( data => {
+            assert.equal('string', typeof Date(data.date));
+            assert.equal('object', typeof data.days);
+            assert.equal('object', typeof data['country-info']);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.statsClicks', function () {
-      it('should request clicks stats', function (done) {
-        site.statsClicks( function (err, data) {
-          if (err) throw err;
-
-          assert.equal('string', typeof Date(data.date));
-          assert.equal('object', typeof data.days);
-          assert.equal('string', typeof data.period);
-          done();
-        });
+      it('should request clicks stats', done => {
+        site.statsClicks()
+          .then( data => {
+            assert.equal('string', typeof Date(data.date));
+            assert.equal('object', typeof data.days);
+            assert.equal('string', typeof data.period);
+            done();
+          })
+          .catch(done);
       });
     });
 
     describe('wpcom.site.statsSearchTerms', function () {
-      it('should request search terms stats', function (done) {
-        site.statsSearchTerms( function (err, data) {
-          if (err) throw err;
-
-          assert.equal('string', typeof Date(data.date));
-          assert.equal('object', typeof data.days);
-          assert.equal('string', typeof data.period);
-          done();
-        });
+      it('should request search terms stats', done => {
+        site.statsSearchTerms()
+          .then( data => {
+            assert.equal('string', typeof Date(data.date));
+            assert.equal('object', typeof data.days);
+            assert.equal('string', typeof data.period);
+            done();
+          })
+          .catch(done);
       });
     });
   });
 
   describe('wpcom.site.get', function () {
-    it('should require site data', function (done) {
-      site.get(function (err, data) {
-        if (err) throw err;
-
-        assert.equal('number', typeof data.ID);
-        assert.equal('string', typeof data.name);
-        done();
-      });
+    it('should require site data', done => {
+      site.get()
+        .then( data => {
+          assert.equal('number', typeof data.ID);
+          assert.equal('string', typeof data.name);
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.addPost', function () {
-    it('should create a new blog post', function (done) {
-      site.addPost(fixture.post, function (err, data) {
-        if (err) throw err;
+    it('should create a new blog post', done => {
+      site.addPost(fixture.post)
+        .then( data => {
+          // store in post ID global var
+          new_post_ID = data.ID;
 
-        // store in post ID global var
-        new_post_ID = data.ID;
-
-        assert.equal('object', typeof data);
-        assert.equal(site_ID, data.site_ID);
-        done();
-      });
+          assert.equal('object', typeof data);
+          assert.equal(site_ID, data.site_ID);
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.deletePost', function () {
-    it('should delete post added', function (done) {
-      site.deletePost(new_post_ID, function (err, data) {
-        if (err) throw err;
-
-        assert.equal('object', typeof data);
-        assert.equal(new_post_ID, data.ID);
-        done();
-      });
+    it('should delete post added', done => {
+      site.deletePost(new_post_ID)
+        .then( data => {
+          assert.equal('object', typeof data);
+          assert.equal(new_post_ID, data.ID);
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.addMediaFiles', function () {
-    it('should create a new media from a file', function (done) {
-      site.addMediaFiles(fixture.media.files, function (err, data) {
-        if (err) throw err;
-
-        assert.ok(data);
-        assert.ok(data.media instanceof Array);
-        assert.equal(fixture.media.files.length, data.media.length);
-        done();
-      });
+    it('should create a new media from a file', done => {
+      site.addMediaFiles(fixture.media.files)
+        .then( data => {
+          assert.ok(data);
+          assert.ok(data.media instanceof Array);
+          assert.equal(fixture.media.files.length, data.media.length);
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.addMediaUrls', function () {
-    it('should create a new site media', function (done) {
-      media = site.addMediaUrls(fixture.media.urls, function (err, data) {
-        if (err) throw err;
-
-        assert.ok(data);
-        assert.ok(data.media instanceof Array);
-        assert.equal(fixture.media.urls.length, data.media.length);
-        done();
-      });
+    it('should create a new site media', done => {
+      media = site.addMediaUrls(fixture.media.urls)
+        .then( data => {
+          assert.ok(data);
+          assert.ok(data.media instanceof Array);
+          assert.equal(fixture.media.urls.length, data.media.length);
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.statsReferrersSpamNew', function() {
     var d = new Date();
     var domain = ( d.getTime() / 1000 ) + 'wordpress.com';
-    it('should mark a domain as spam', function (done) {
-      site.statsReferrersSpamNew( domain, function(err, data) {
-        if (err) throw err;
-
-        assert.ok(data);
-        done();
-      });
+    it('should mark a domain as spam', done => {
+      site.statsReferrersSpamNew( domain )
+        .then( data => {
+          assert.ok(data);
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.statsReferrersSpamDelete', function() {
     var d = new Date();
     var domain = ( d.getTime() / 1000 ) + 'wordpress.com';
-    it('should remove a domain from spam refferer list', function (done) {
-      site.statsReferrersSpamDelete( domain, function(err, data) {
-        if (err) throw err;
-
-        assert.ok(data);
-        done();
-      });
+    it('should remove a domain from spam refferer list', done => {
+      site.statsReferrersSpamDelete( domain )
+        .then( data => {
+          assert.ok(data);
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.statsPostViews', function() {
-    it('should request post stat details', function (done) {
-      site.statsPostViews( testing_post.ID, function(err, data) {
-        if (err) throw err;
-
-        assert.ok(data);
-        assert.equal('string', typeof Date(data.date));
-        assert.equal('number', typeof data.views);
-        assert.equal('number', typeof data.highest_month);
-        assert.equal('number', typeof data.highest_day_average);
-        assert.equal('number', typeof data.highest_week_average);
-        assert.ok(data.post instanceof Object);
-        assert.ok(data.years instanceof Object);
-        assert.ok(data.weeks instanceof Object);
-        assert.ok(data.fields instanceof Array);
-        assert.ok(data.data instanceof Array);
-        assert.ok(data.averages instanceof Object);
-        done();
-      });
+    it('should request post stat details', done => {
+      site.statsPostViews( testing_post.ID )
+        .then( data => {
+          assert.ok(data);
+          assert.equal('string', typeof Date(data.date));
+          assert.equal('number', typeof data.views);
+          assert.equal('number', typeof data.highest_month);
+          assert.equal('number', typeof data.highest_day_average);
+          assert.equal('number', typeof data.highest_week_average);
+          assert.ok(data.post instanceof Object);
+          assert.ok(data.years instanceof Object);
+          assert.ok(data.weeks instanceof Object);
+          assert.ok(data.fields instanceof Array);
+          assert.ok(data.data instanceof Array);
+          assert.ok(data.averages instanceof Object);
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.statsVideo', function() {
-    it('should request video stats', function (done) {
-      site.statsVideo( testing_post.ID, function(err, data) {
-        if (err) throw err;
-
-        assert.ok(data);
-        assert(data.fields instanceof Array);
-        assert(data.data instanceof Array);
-        assert(data.pages instanceof Array);
-        done();
-      });
+    it('should request video stats', done => {
+      site.statsVideo( testing_post.ID )
+        .then( data => {
+          assert.ok(data);
+          assert(data.fields instanceof Array);
+          assert(data.data instanceof Array);
+          assert(data.pages instanceof Array);
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.pageTemplates', function() {
-    it('should request page templates', function (done) {
-      site.pageTemplates( function(err, data) {
-        if (err) throw err;
-
-        assert.ok(data);
-        assert(data.templates instanceof Array);
-        done();
-      });
+    it('should request page templates', done => {
+      site.pageTemplates()
+        .then( data => {
+          assert.ok(data);
+          assert(data.templates instanceof Array);
+          done();
+        })
+        .catch(done);
     });
   });
 });

--- a/test/test.wpcom.site.media.js
+++ b/test/test.wpcom.site.media.js
@@ -26,124 +26,103 @@ describe('wpcom.site.media', function(){
   // Create a testing_media before to start tests
 
   var testing_media;
-  before(function(done){
-    site.addMediaFiles(fixture.media.files[1], function(err, data) {
-      if (err) throw err;
-
-      testing_media = data ? data.media[0] : {};
-      done();
-    });
+  before( done => {
+    site.addMediaFiles(fixture.media.files[1])
+      .then( data => {
+        testing_media = data ? data.media[0] : {};
+        done();
+      })
+      .catch(done);
   });
 
-  after(function(done){
+  after( done => {
     // clean media added through of array by urls
-    site.deleteMedia(add_urls_array.media[0].ID, function(err, data) {
-      if (err) throw err;
-
-      site.deleteMedia(add_urls_array.media[1].ID, function(err, data) {
-        if (err) throw err;
-
-        site.deleteMedia(add_urls_array.media[2].ID, function(err, data) {
-          if (err) throw err;
-
-          site.deleteMedia(add_urls_object.media[0].ID, function(err, data) {
-            if (err) throw err;
-
-            done();
-          });
-        });
-      });
-    });
+    site.deleteMedia(add_urls_array.media[0].ID)
+      .then( () => site.deleteMedia(add_urls_array.media[1].ID) )
+      .then( () => site.deleteMedia(add_urls_array.media[2].ID) )
+      .then( () => site.deleteMedia(add_urls_object.media[0].ID) )
+      .then( () => done() )
+      .catch(done);
   });
 
   describe('wpcom.site.media.get', function(){
-    it('should get added media', function(done){
+    it('should get added media', done => {
       var media = site.media(testing_media.ID);
-      media.get(function(err, data){
-        if (err) throw err;
-
-        assert.equal(testing_media.ID, data.ID);
-        done();
-      });
+      media.get()
+        .then( data => {
+          assert.equal(testing_media.ID, data.ID);
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.media.update', function(){
-    it('should edit the media title', function(done){
+    it('should edit the media title', done => {
       var edited_title = "This is the new title";
 
-      site
-      .media(testing_media.ID)
-      .update({ apiVersion: '1.1' }, { title: edited_title }, function(err, data){
-        if (err) throw err;
+      site.media(testing_media.ID).update({ apiVersion: '1.1' }, { title: edited_title })
+        .then( data => {
+          assert.ok(data);
+          assert.equal(edited_title, data.title);
 
-        assert.ok(data);
-        assert.equal(edited_title, data.title);
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.media.addFiles', function(){
-    it('should create a new media from a file', function(done){
-      site
-      .media()
-      .addFiles(fixture.media.files, function(err, data){
-        if (err) throw err;
-
-        assert.ok(data);
-        assert.ok(data.media instanceof Array);
-        assert.equal(fixture.media.files.length, data.media.length);
-        done();
-      });
+    it('should create a new media from a file', done => {
+      site.media().addFiles(fixture.media.files)
+        .then( data => {
+          assert.ok(data);
+          assert.ok(data.media instanceof Array);
+          assert.equal(fixture.media.files.length, data.media.length);
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.media.addUrls', function(){
-    it('should create a new media from an object', function(done){
+    it('should create a new media from an object', done => {
       var media_object = fixture.media.urls[1];
 
-      site
-      .media()
-      .addUrls(media_object, function(err, data){
-        if (err) throw err;
-
-        assert.ok(data);
-        add_urls_object = data;
-        done();
-      });
+      site.media().addUrls(media_object)
+        .then( data => {
+          assert.ok(data);
+          add_urls_object = data;
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.media.addUrls', function(){
-    it('should create a new media', function(done){
-      site
-      .media()
-      .addUrls(fixture.media.urls, function(err, data){
-        if (err) throw err;
+    it('should create a new media', done => {
+      site.media().addUrls(fixture.media.urls)
+        .then( data => {
+          assert.ok(data);
+          assert.ok(data.media instanceof Array);
+          assert.equal(fixture.media.urls.length, data.media.length);
 
-        assert.ok(data);
-        assert.ok(data.media instanceof Array);
-        assert.equal(fixture.media.urls.length, data.media.length);
+          add_urls_array = data;
 
-        add_urls_array = data;
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.media.delete', function(){
-    it('should delete a media', function(done){
-      site
-      .media(testing_media.ID)
-      .del(function(err, data){
-        if (err) throw err;
-
-        assert.equal(testing_media.ID, data.ID);
-        done();
-      });
+    it('should delete a media', done => {
+      site.media(testing_media.ID).del()
+        .then( data => {
+          assert.equal(testing_media.ID, data.ID);
+          done();
+        })
+        .catch(done);
     });
   });
 

--- a/test/test.wpcom.site.post.comment.js
+++ b/test/test.wpcom.site.post.comment.js
@@ -23,23 +23,19 @@ describe('wpcom.site.post.comment', function(){
   var testing_post;
   var testing_comment;
 
-  before(function(done){
-    site.addPost(fixture.post, function (err, data) {
-      if (err) throw err;
+  before( done => {
+    site.addPost(fixture.post)
+      .then( data => {
+        testing_post = site.post(data.ID);
 
-      testing_post = site.post(data.ID);
-
-      // Add comment to post
-      site
-      .post(data.ID)
-      .comment()
-      .add(fixture.post_comment, function (err, data_comment) {
-        if (err) throw err;
-
+        // Add comment to post
+        return site.post(data.ID).comment().add(fixture.post_comment);
+      })
+      .then( data_comment => {
         testing_comment = testing_post.comment(data_comment.ID);
         done();
-      });
-    });
+      })
+      .catch(done);
   });
 
   after(function(done){

--- a/test/test.wpcom.site.post.like.js
+++ b/test/test.wpcom.site.post.like.js
@@ -24,89 +24,80 @@ describe('wpcom.site.post.like', function(){
   var testing_post;
 
   // Create a testing_post before to start the tests
-  before(function(done){
-    site.addPost(fixture.post, function (err, data) {
-      if (err) throw err;
-
-      testing_post = site.post(data.ID);
-      done();
-    });
+  before( done => {
+    site.addPost(fixture.post)
+      .then( data => {
+        testing_post = site.post(data.ID);
+        done();
+      })
+      .catch(done);
   });
 
-  after(function(done){
+  after( done => {
     // delete testing_post post
-    testing_post.delete(function(err, post) {
-      if (err) throw err;
-
-      done();
-    });
+    testing_post.delete()
+      .then( () => done() )
+      .catch(done);
   });
 
   describe('wpcom.site.post.like.add', function(){
-    it('should add a post like', function(done){
-      testing_post
-      .like()
-      .add(function(err, data){
-        if (err) throw err;
+    it('should add a post like', done => {
+      testing_post.like().add()
+        .then( data => {
+          assert.ok(data);
+          assert.ok(data.success);
+          assert.ok(data.i_like);
+          assert.equal(1, data.like_count);
 
-        assert.ok(data);
-        assert.ok(data.success);
-        assert.ok(data.i_like);
-        assert.equal(1, data.like_count);
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.post.like.mine', function(){
-    it('should get the post like status of mine', function(done){
-      testing_post
-      .like()
-      .mine(function(err, data){
-        if (err) throw err;
+    it('should get the post like status of mine', done => {
+      testing_post.like().mine()
+        .then( data => {
+          assert.ok(data);
+          assert.equal(1, data.like_count);
+          assert.ok(data.i_like);
 
-        assert.ok(data);
-        assert.equal(1, data.like_count);
-        assert.ok(data.i_like);
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.post.likesList', function(){
-    it('should get post likes list', function(done){
-      testing_post
-      .likesList(function(err, data){
-        if (err) throw err;
+    it('should get post likes list', done => {
+      testing_post.likesList()
+        .then( data => {
+          assert.ok(data);
 
-        assert.ok(data);
+          assert.equal('number', typeof data.found);
+          assert.equal('boolean', typeof data.i_like);
+          assert.equal('object', typeof data.likes);
+          assert.ok(data.likes instanceof Array);
 
-        assert.equal('number', typeof data.found);
-        assert.equal('boolean', typeof data.i_like);
-        assert.equal('object', typeof data.likes);
-        assert.ok(data.likes instanceof Array);
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.post.like.delete', function(){
-    it('should remove your like from the post', function(done){
-      testing_post
-      .like()
-      .del(function(err, data){
-        if (err) throw err;
+    it('should remove your like from the post', done => {
+      testing_post.like().del()
+        .then( data => {
+          assert.ok(data);
+          assert.ok(data.success);
+          assert.equal(0, data.like_count);
+          assert.ok(!(data.i_like));
 
-        assert.ok(data);
-        assert.ok(data.success);
-        assert.equal(0, data.like_count);
-        assert.ok(!(data.i_like));
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 

--- a/test/test.wpcom.site.post.reblog.js
+++ b/test/test.wpcom.site.post.reblog.js
@@ -26,64 +26,59 @@ describe('wpcom.site.post.reblog', function(){
   var testing_post;
 
   // Create a testing_post before to start tests
-  before(function(done){
-    site.addPost(fixture.post, function (err, data) {
-      if (err) throw err;
-
-      testing_post = site.post(data.ID);
-      done();
-    });
+  before( done => {
+    site.addPost(fixture.post)
+      .then( data => {
+        testing_post = site.post(data.ID);
+        done();
+      })
+      .catch(done);
   });
 
-  after(function(done){
+  after( done => {
     // delete testing_post post
-    testing_post.delete(function(err, post) {
-      if (err) throw err;
-
-      done();
-    });
+    testing_post.delete()
+      .then(() => done())
+      .catch(done);
   });
 
 
   describe('wpcom.site.post.reblog.add', function() {
-    it('should reblog the added post', function (done) {
-      testing_reblog_post
-      .reblog()
-      .add({ note: fixture.reblog.note, destination_site_id: site._id }, function (err, data){
-        if (err) throw err;
-
-        assert.ok(data);
-        assert.ok(data.can_reblog);
-        done();
-      });
+    it('should reblog the added post', done => {
+      testing_reblog_post.reblog().add({
+          note: fixture.reblog.note,
+          destination_site_id: site._id
+        })
+        .then( data => {
+          assert.ok(data);
+          assert.ok(data.can_reblog);
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.post.reblog.to', function(){
-    it('should get reblog the added post', function(done){
-      testing_reblog_post
-      .reblog()
-      .to(site._id, fixture.reblog.note + '-to', function (err, data){
-        if (err) throw err;
-
-        assert.ok(data);
-        assert.ok(data.can_reblog);
-        done();
-      });
+    it('should get reblog the added post', done => {
+      testing_reblog_post.reblog().to(site._id, fixture.reblog.note + '-to')
+        .then( data => {
+          assert.ok(data);
+          assert.ok(data.can_reblog);
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.post.reblog.mine', function(){
-    it('should get the post reblog status of mine', function(done){
-      testing_post
-      .reblog()
-      .mine(function(err, data){
-        if (err) throw err;
-
-        assert.ok(data);
-        assert.ok(data.can_reblog);
-        done();
-      });
+    it('should get the post reblog status of mine', done => {
+      testing_post.reblog().mine()
+        .then( data => {
+          assert.ok(data);
+          assert.ok(data.can_reblog);
+          done();
+        })
+        .catch(done);
     });
   });
 

--- a/test/test.wpcom.site.shortcodes.js
+++ b/test/test.wpcom.site.shortcodes.js
@@ -23,37 +23,35 @@ describe('wpcom.site.shortcodes', function () {
   var testing_media;
 
   // add media testing
-  before(function(done){
-    site.addMediaFiles(fixture.media.files[0], function(err, data) {
-      if (err) throw err;
-
-      testing_media = data ? data.media[0] : {};
-      done();
-    });
+  before( done => {
+    site.addMediaFiles(fixture.media.files[0])
+      .then( data => {
+        testing_media = data ? data.media[0] : {};
+        done();
+      })
+      .catch(done);
   });
 
-  after(function(done){
+  after( done => {
     // delete media testing
-    site.deleteMedia(testing_media.ID, function(err, data) {
-      if (err) throw err;
-      
-      done();
-    });
+    site.deleteMedia(testing_media.ID)
+      .then(() => done())
+      .catch(done);
   });
 
   describe('wpcom.site.renderShortcode(\'gallery\')', function () {
-    it('should render [gallery] shortcode', function(done){
+    it('should render [gallery] shortcode', done => {
 
       var shortcode = '[gallery ids="' + testing_media.ID + '"]';
-      site.renderShortcode(shortcode, function(err, data){
-        if (err) throw err;
-
-        assert.equal(data.shortcode, shortcode);
-        assert.ok(data.result);
-        assert.ok(data.scripts);
-        assert.ok(data.styles);
-        done();
-      });
+      site.renderShortcode(shortcode)
+        .then( data => {
+          assert.equal(data.shortcode, shortcode);
+          assert.ok(data.result);
+          assert.ok(data.scripts);
+          assert.ok(data.styles);
+          done();
+        })
+        .catch(done);
     });
   });
 

--- a/test/test.wpcom.site.tag.js
+++ b/test/test.wpcom.site.tag.js
@@ -24,95 +24,91 @@ describe('wpcom.site.tag', function(){
 
   // Create a testing_tag before to start tests
   var testing_tag;
-  before(function(done){
+  before( done => {
     fixture.tag.name += Math.random() * 1000000 | 0;
-    site.tag()
-    .add(fixture.tag, function(err, tag) {
-      if (err) throw err;
-
-      testing_tag = tag;
-      done();
-    });
+    site.tag().add(fixture.tag)
+      .then( tag => {
+        testing_tag = tag;
+        done();
+      })
+      .catch(done);
   });
 
   // Delete testing tag
-  after(function(done){
-    site.tag(testing_tag.slug)
-    .delete(function(err, tag) {
-      if (err) throw err;
-
-      done();
-    });
+  after( done => {
+    site.tag(testing_tag.slug).delete()
+      .then(() => done())
+      .catch(done);
   });
 
   describe('wpcom.site.tag.get', function(){
-    it('should get added tag', function(done){
+    it('should get added tag', done => {
       var cat = site.tag(testing_tag.slug);
 
-      cat.get(function(err, data){
-        if (err) throw err;
-
-        assert.ok(data);
-        assert.ok(data instanceof Object, 'data is not an object');
-        assert.equal(testing_tag.slug, data.slug);
-        assert.equal(testing_tag.name, data.name);
-        done();
-      });
+      cat.get()
+        .then( data => {
+          assert.ok(data);
+          assert.ok(data instanceof Object, 'data is not an object');
+          assert.equal(testing_tag.slug, data.slug);
+          assert.equal(testing_tag.name, data.name);
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.tag.add', function(){
-    it('should add a new tag', function(done){
+    it('should add a new tag', done => {
       var tag = site.tag();
       fixture.tag.name += '-added';
 
-      tag.add(fixture.tag, function(err, data){
-        if (err) throw err;
+      tag.add(fixture.tag)
+        .then( data => {
+          // checking some data date
+          assert.ok(data);
+          assert.ok(data instanceof Object, 'data is not an object');
 
-        // checking some data date
-        assert.ok(data);
-        assert.ok(data instanceof Object, 'data is not an object');
+          // store added catogory
+          new_tag = data;
 
-        // store added catogory
-        new_tag = data;
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.tag.update', function(){
-    it('should edit the new added tag', function(done){
+    it('should edit the new added tag', done => {
       var tag = site.tag(new_tag.slug);
       var edited_name = fixture.tag.name + '-updated';
 
-      tag.update({ name: edited_name }, function(err, data){
-        if (err) throw err;
+      tag.update({ name: edited_name })
+        .then( data => {
+          assert.ok(data);
+          assert.equal(edited_name, data.name);
 
-        assert.ok(data);
-        assert.equal(edited_name, data.name);
+          // update added tag
+          new_tag = data;
 
-        // update added tag
-        new_tag = data;
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 
   describe('wpcom.site.tag.delete', function() {
-    it('should delete the new added tag', function(done) {
+    it('should delete the new added tag', done => {
       var cat = site.tag(new_tag.slug);
 
-      cat.delete(function(err, data) {
-        if (err) throw err;
+      cat.delete()
+        .then( data => {
+          assert.ok(data);
+          assert.equal("true", data.success);
+          assert.equal(new_tag.slug, data.slug);
 
-        assert.ok(data);
-        assert.equal("true", data.success);
-        assert.equal(new_tag.slug, data.slug);
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 

--- a/test/test.wpcom.users.js
+++ b/test/test.wpcom.users.js
@@ -22,16 +22,16 @@ describe('wpcom.users', function () {
   var users = wpcom.users();
 
   describe('wpcom.users.suggets', function() {
-    it('should get a list of possible users to suggest.', function (done) {
-      users.suggest(function (err, data) {
-        if (err) throw err;
+    it('should get a list of possible users to suggest.', done => {
+      users.suggest()
+        .then( data => {
+          assert.ok(data);
+          assert.equal('object', typeof data.suggestions);
+          assert.ok(data.suggestions instanceof Array);
 
-        assert.ok(data);
-        assert.equal('object', typeof data.suggestions);
-        assert.ok(data.suggestions instanceof Array);
-
-        done();
-      });
+          done();
+        })
+        .catch(done);
     });
   });
 

--- a/test/util.js
+++ b/test/util.js
@@ -41,13 +41,8 @@ function wpcom() {
     var proxy = require('../node_modules/wpcom-proxy-request');
     var _wpcom = WPCOM(proxy);
 
-    _wpcom.request({
-      metaAPI: { accessAllUsersBlogs: true }
-    }, function(err) {
-      if (err) throw err;
-      console.log('proxy now running in "access all user\'s blogs" mode');
-    });
-
+    _wpcom.request({ metaAPI: { accessAllUsersBlogs: true }})
+      .then( () => console.log('proxy now running in "access all user\'s blogs" mode') );
     return _wpcom;
   } else {
     return WPCOM(token);


### PR DESCRIPTION
Contrast to the wrapper approach in #112. This introduces Promises in a much smoother and less obtuse way.

Previously, if no callback were passed into the wpcom requests, a
default callback that threw an exception on error was introduced and
executed.

Now, however, we can use the absence of a callback to indicate that we
would prefer to have a promise returned that rejects or resolves
corresponding to the API response.

This requires support for promises, however, meaning that `wpcom.js`
will need to be built inside of a project that transpiles or polyfills.