### PR TITLE
Add `esformatter` and `eslint` configs.

### DIFF
--- a/.esformatter
+++ b/.esformatter
@@ -1,0 +1,76 @@
+{
+	"root": true,
+
+	"preset": "default",
+	"indent": {
+		"value": "\t",
+		"IfStatementConditional": 2,
+		"SwitchStatement": 1,
+		"TopLevelFunctionBlock": 1
+	},
+	"lineBreak": {
+		"before": {
+			"VariableDeclarationWithoutInit": 0,
+			"ArrayExpressionClosing": 1
+		},
+		"after": {
+			"AssignmentOperator": -1,
+			"ArrayExpressionOpening": 1,
+			"ArrayExpressionComma": 1
+		}
+	},
+	"whiteSpace": {
+		"before": {
+			"ArgumentList": 1,
+			"ArgumentListArrayExpression": 1,
+			"ArgumentListFunctionExpression": 1,
+			"ArgumentListObjectExpression": 1,
+			"ArrayExpressionClosing": 1,
+			"ExpressionClosingParentheses": 1,
+			"ForInStatementExpressionClosing": 1,
+			"ForStatementExpressionClosing": 1,
+			"IfStatementConditionalClosing": 1,
+			"MemberExpressionClosing": 1,
+			"ParameterList": 1,
+			"SwitchDiscriminantClosing": 1,
+			"WhileStatementConditionalClosing": 1,
+			"CallExpression": -1
+		},
+		"after": {
+			"ArgumentList": 1,
+			"ArgumentListArrayExpression": 1,
+			"ArgumentListFunctionExpression": 1,
+			"ArgumentListObjectExpression": 1,
+			"ArrayExpressionOpening": 1,
+			"ExpressionOpeningParentheses": 1,
+			"ForInStatementExpressionOpening": 1,
+			"ForStatementExpressionOpening": 1,
+			"IfStatementConditionalOpening": 1,
+			"MemberExpressionOpening": 1,
+			"ParameterList": 1,
+			"SwitchDiscriminantOpening": 1,
+			"WhileStatementConditionalOpening": 1,
+			"CallExpression": 0
+		}
+	},
+	"collapseObjects": {
+		"ObjectExpression": {
+			"maxLineLength": 120,
+			"maxKeys": 1,
+			"forbidden": [ "FunctionExpression" ]
+		},
+		"ArrayExpression": {
+			"maxLineLength": 120,
+			"maxKeys": 10,
+			"forbidden": [ "FunctionExpression" ]
+		}
+	},
+	"plugins": [
+		"esformatter-quotes",
+		"esformatter-semicolons",
+		"esformatter-braces",
+		"esformatter-dot-notation",
+		"esformatter-special-bangs",
+		"esformatter-jsx-ignore"
+	]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,79 @@
+{
+	"parser": "babel-eslint",
+	"env": {
+		"browser": true,
+		"es6": true,
+		"mocha": true,
+		"node": true
+	},
+	"ecmaFeatures": {
+		"jsx": true,
+		"modules": true
+	},
+	"plugins": [
+		"eslint-plugin-react"
+	],
+	"rules": {
+		"brace-style": [ 1, "1tbs" ],
+		// REST API objects include underscores
+		"camelcase": 0,
+		"comma-dangle": 0,
+		"comma-spacing": 1,
+		// Allows returning early as undefined
+		"consistent-return": 0,
+		"dot-notation": 1,
+		"eqeqeq": [ 2, "allow-null" ],
+		"eol-last": 1,
+		"indent": [ 1, "tab", { "SwitchCase": 1 } ],
+		"key-spacing": 1,
+		// Most common is "Emitter", should be improved
+		"new-cap": 1,
+		"no-cond-assign": 2,
+		"no-else-return": 1,
+		"no-empty": 1,
+		// Flux stores use switch case fallthrough
+		"no-fallthrough": 0,
+		"no-lonely-if": 1,
+		"no-mixed-requires": 0,
+		"no-mixed-spaces-and-tabs": 1,
+		"no-multiple-empty-lines": [ 1, { max: 1 } ],
+		"no-multi-spaces": 1,
+		"no-nested-ternary": 1,
+		"no-new": 1,
+		"no-process-exit": 1,
+		"no-shadow": 1,
+		"no-spaced-func": 1,
+		"no-trailing-spaces": 1,
+		"no-underscore-dangle": 0,
+		// Allows Chai `expect` expressions
+		"no-unused-expressions": 0,
+		"no-unused-vars": 1,
+		// Teach eslint about React+JSX
+		"react/jsx-uses-react": 1,
+		"react/jsx-uses-vars": 1,
+		// Allows function use before declaration
+		"no-use-before-define": [ 2, "nofunc" ],
+		// We split external, internal, module variables
+		"one-var": 0,
+		"operator-linebreak": [ 1, "after" ],
+		"padded-blocks": [ 1, "never" ],
+		"quote-props": [ 1, "as-needed" ],
+		"quotes": [ 1, "single", "avoid-escape" ],
+		"semi-spacing": 1,
+		"space-after-keywords": [ 1, "always" ],
+		"space-before-blocks": [ 1, "always" ],
+		"space-before-function-paren": [ 1, "never" ],
+		// Our array literal index exception violates this rule
+		"space-in-brackets": 0,
+		"space-in-parens": [ 1, "always" ],
+		"space-infix-ops": [ 1, { "int32Hint": false } ],
+		// Ideal for "!" but not for "++"
+		"space-unary-ops": 0,
+		// Assumed by default with Babel
+		"strict": [ 2, "never" ],
+		"valid-jsdoc": [ 1, { "requireReturn": false } ],
+		// Common top-of-file requires, expressions between external, interal
+		"vars-on-top": 1,
+		"yoda": 0
+	}
+}

--- a/index.js
+++ b/index.js
@@ -1,22 +1,20 @@
-
-
 /**
  * Module dependencies.
  */
 
-var request_handler = require('wpcom-xhr-request');
+var request_handler = require( 'wpcom-xhr-request' );
 
 /**
  * Local module dependencies.
  */
 
-var Me = require('./lib/me');
-var Site = require('./lib/site');
-var Users = require('./lib/users');
-var Batch = require('./lib/batch');
-var Req = require('./lib/util/request');
-var sendRequest = require('./lib/util/send-request');
-var debug = require('debug')('wpcom');
+var Me = require( './lib/me' );
+var Site = require( './lib/site' );
+var Users = require( './lib/users' );
+var Batch = require( './lib/batch' );
+var Req = require( './lib/util/request' );
+var sendRequest = require( './lib/util/send-request' );
+var debug = require( 'debug' )( 'wpcom' );
 
 /**
  * Local module constants
@@ -36,45 +34,45 @@ var DEFAULT_ASYNC_TIMEOUT = 30000;
  * @public
  */
 
-function WPCOM(token, reqHandler) {
-  if (!(this instanceof WPCOM)) {
-    return new WPCOM(token, reqHandler);
-  }
+function WPCOM( token, reqHandler ) {
+	if ( ! ( this instanceof WPCOM ) ) {
+		return new WPCOM( token, reqHandler );
+	}
 
-  // `token` is optional
-  if ('function' === typeof token) {
-    reqHandler = token;
-    token = null;
-  }
+	// `token` is optional
+	if ( 'function' === typeof token ) {
+		reqHandler = token;
+		token = null;
+	}
 
-  if (token) {
-    debug('Token defined: %s…', token.substring(0, 6));
-    this.token = token;
-  }
+	if ( token ) {
+		debug( 'Token defined: %s…', token.substring( 0, 6 ) );
+		this.token = token;
+	}
 
-  // Set default request handler
-  if (!reqHandler) {
-    debug('No request handler. Adding default XHR request handler');
+	// Set default request handler
+	if ( ! reqHandler ) {
+		debug( 'No request handler. Adding default XHR request handler' );
 
-    this.request = function (params, fn) {
-      params = params || {};
+		this.request = function( params, fn ) {
+			params = params || {};
 
-      // token is optional
-      if (token) {
-        params.authToken = token;
-      }
+			// token is optional
+			if ( token ) {
+				params.authToken = token;
+			}
 
-      return request_handler(params, fn);
-    };
-  } else {
-    this.request = reqHandler;
-  }
+			return request_handler( params, fn );
+		};
+	} else {
+		this.request = reqHandler;
+	}
 
-  // Add Req instance
-  this.req = new Req(this);
+	// Add Req instance
+	this.req = new Req( this );
 
-  // Default api version;
-  this.apiVersion = '1.1';
+	// Default api version;
+	this.apiVersion = '1.1';
 }
 
 /**
@@ -83,8 +81,8 @@ function WPCOM(token, reqHandler) {
  * @api public
  */
 
-WPCOM.prototype.me = function () {
-  return new Me(this);
+WPCOM.prototype.me = function() {
+	return new Me( this );
 };
 
 /**
@@ -94,8 +92,8 @@ WPCOM.prototype.me = function () {
  * @api public
  */
 
-WPCOM.prototype.site = function (id) {
-  return new Site(id, this);
+WPCOM.prototype.site = function( id ) {
+	return new Site( id, this );
 };
 
 /**
@@ -104,13 +102,12 @@ WPCOM.prototype.site = function (id) {
  * @api public
  */
 
-WPCOM.prototype.users = function () {
-  return new Users(this);
+WPCOM.prototype.users = function() {
+	return new Users( this );
 };
 
-
-WPCOM.prototype.batch = function () {
-  return new Batch(this);
+WPCOM.prototype.batch = function() {
+	return new Batch( this );
 };
 
 /**
@@ -121,8 +118,8 @@ WPCOM.prototype.batch = function () {
  * @api public
  */
 
-WPCOM.prototype.freshlyPressed = function (query, fn) {
-  return this.req.get('/freshly-pressed', query, fn);
+WPCOM.prototype.freshlyPressed = function( query, fn ) {
+	return this.req.get( '/freshly-pressed', query, fn );
 };
 
 /**
@@ -130,15 +127,15 @@ WPCOM.prototype.freshlyPressed = function (query, fn) {
  * @TODO: use `this.req` instead of this method
  */
 
-WPCOM.prototype.sendRequest = function (params, query, body, fn) {
-  var msg = 'WARN! Don use `sendRequest() anymore. Use `this.req` method.';
-  if (console && console.warn) {
-    console.warn(msg);
-  } else {
-    console.log(msg);
-  }
+WPCOM.prototype.sendRequest = function( params, query, body, fn ) {
+	var msg = 'WARN! Don use `sendRequest() anymore. Use `this.req` method.';
+	if ( console && console.warn ) {
+		console.warn( msg );
+	} else {
+		console.log( msg );
+	}
 
-  return sendRequest.call(this, params, query, body, fn)
+	return sendRequest.call( this, params, query, body, fn );
 };
 
 /**
@@ -154,17 +151,17 @@ WPCOM.prototype.sendRequest = function (params, query, body, fn) {
  * an API call is not empty. It resolves otherwise.
  *
  * @param {function} callback wpcom.js method to call
- * @param params variable list of parameters to send to callback
- * @returns {Promise}
+ * @param {*} params variable list of parameters to send to callback
+ * @returns {Promise} Promise following the callback's error/success
  */
 WPCOM.prototype.Promise = ( callback, ...params ) => {
-  return new Promise( ( resolve, reject ) => {
-    // The functions here take a variable number of arguments,
-    // so pass in as many as we can but keep the callback last.
-    callback.apply( callback, [...params, ( error, data ) => {
-      error ? reject( error ) : resolve( data );
-    } ] );
-  } );
+	return new Promise( ( resolve, reject ) => {
+		// The functions here take a variable number of arguments,
+		// so pass in as many as we can but keep the callback last.
+		callback.apply( callback, params.concat( ( error, data ) => {
+			error ? reject( error ) : resolve( data );
+		} ) );
+	} );
 };
 
 if ( ! Promise.prototype.timeout ) {
@@ -176,24 +173,27 @@ if ( ! Promise.prototype.timeout ) {
      * the deadline, the timer is cancelled.
      *
      * @param {number} delay how many ms to wait
-     * @returns {Promise}
+     * @returns {Promise} Race between the calling promise and the timeout
      */
-  Promise.prototype.timeout = function( delay = DEFAULT_ASYNC_TIMEOUT ) {
-    let cancelTimeout, timer, timeout;
+	Promise.prototype.timeout = function( delay = DEFAULT_ASYNC_TIMEOUT ) {
+		let cancelTimeout, timer, timeout;
 
-    timeout = new Promise( ( resolve, reject ) => {
-      timer = setTimeout( () => {
-        reject( new Error( 'Action timed out while waiting for response.' ) );
-      }, delay );
-    } );
+		timeout = new Promise( ( resolve, reject ) => {
+			timer = setTimeout( ( ) => {
+				reject( new Error( 'Action timed out while waiting for response.' ) );
+			}, delay );
+		} );
 
-    cancelTimeout = () => {
-      clearTimeout( timer );
-      return this;
-    };
+		cancelTimeout = ( ) => {
+			clearTimeout( timer );
+			return this;
+		};
 
-    return Promise.race( [ this.then( cancelTimeout ).catch( cancelTimeout ), timeout ] );
-  };
+		return Promise.race( [
+			this.then( cancelTimeout ).catch( cancelTimeout ),
+			timeout
+		] );
+	};
 }
 
 /**

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -1,10 +1,3 @@
-
-/**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:batch');
-
 /**
  * Create a `Batch` instance
  *
@@ -12,14 +5,14 @@ var debug = require('debug')('wpcom:batch');
  * @api public
  */
 
-function Batch(wpcom) {
-  if (!(this instanceof Batch)) {
-    return new Batch(wpcom);
-  }
+function Batch( wpcom ) {
+	if ( ! ( this instanceof Batch ) ) {
+		return new Batch( wpcom );
+	}
 
-  this.wpcom = wpcom;
+	this.wpcom = wpcom;
 
-  this.urls = [];
+	this.urls = [];
 }
 
 /**
@@ -29,9 +22,9 @@ function Batch(wpcom) {
  * @api public
  */
 
-Batch.prototype.add = function (url) {
-  this.urls.push(url);
-  return this;
+Batch.prototype.add = function( url ) {
+	this.urls.push( url );
+	return this;
 };
 
 /**
@@ -42,16 +35,16 @@ Batch.prototype.add = function (url) {
  * @api public
  */
 
-Batch.prototype.run = function (query={}, fn) {
-  if ('function' === typeof query) {
-    fn = query;
-    query = {};
-  }
+Batch.prototype.run = function( query = {}, fn ) {
+	if ( 'function' === typeof query ) {
+		fn = query;
+		query = {};
+	}
 
-  // add urls to query object
-  query['urls'] = this.urls;
+	// add urls to query object
+	query.urls = this.urls;
 
-  return this.wpcom.req.get('/batch', query, fn);
+	return this.wpcom.req.get( '/batch', query, fn );
 };
 
 /**

--- a/lib/category.js
+++ b/lib/category.js
@@ -1,10 +1,3 @@
-
-/**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:category');
-
 /**
  * Category methods
  *
@@ -14,18 +7,18 @@ var debug = require('debug')('wpcom:category');
  * @api public
  */
 
-function Category(slug, sid, wpcom) {
-  if (!sid) {
-    throw new Error('`site id` is not correctly defined');
-  }
+function Category( slug, sid, wpcom ) {
+	if ( ! sid ) {
+		throw new Error( '`site id` is not correctly defined' );
+	}
 
-  if (!(this instanceof Category)) {
-    return new Category(slug, sid, wpcom);
-  }
+	if ( ! ( this instanceof Category ) ) {
+		return new Category( slug, sid, wpcom );
+	}
 
-  this.wpcom = wpcom;
-  this._sid = sid;
-  this._slug = slug;
+	this.wpcom = wpcom;
+	this._sid = sid;
+	this._slug = slug;
 }
 
 /**
@@ -35,8 +28,8 @@ function Category(slug, sid, wpcom) {
  * @api public
  */
 
-Category.prototype.slug = function (slug) {
-  this._slug = slug;
+Category.prototype.slug = function( slug ) {
+	this._slug = slug;
 };
 
 /**
@@ -47,9 +40,9 @@ Category.prototype.slug = function (slug) {
  * @api public
  */
 
-Category.prototype.get = function (query, fn) {
-  var path = '/sites/' + this._sid + '/categories/slug:' + this._slug;
-  return this.wpcom.req.get(path, query, fn);
+Category.prototype.get = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/categories/slug:' + this._slug;
+	return this.wpcom.req.get( path, query, fn );
 };
 
 /**
@@ -61,9 +54,9 @@ Category.prototype.get = function (query, fn) {
  * @api public
  */
 
-Category.prototype.add = function (query, body, fn) {
-  var path = '/sites/' + this._sid + '/categories/new';
-  return this.wpcom.req.post(path, query, body, fn);
+Category.prototype.add = function( query, body, fn ) {
+	var path = '/sites/' + this._sid + '/categories/new';
+	return this.wpcom.req.post( path, query, body, fn );
 };
 
 /**
@@ -75,9 +68,9 @@ Category.prototype.add = function (query, body, fn) {
  * @api public
  */
 
-Category.prototype.update = function (query, body, fn) {
-  var path = '/sites/' + this._sid + '/categories/slug:' + this._slug;
-  return this.wpcom.req.put(path, query, body, fn);
+Category.prototype.update = function( query, body, fn ) {
+	var path = '/sites/' + this._sid + '/categories/slug:' + this._slug;
+	return this.wpcom.req.put( path, query, body, fn );
 };
 
 /**
@@ -88,9 +81,9 @@ Category.prototype.update = function (query, body, fn) {
  * @api public
  */
 
-Category.prototype['delete'] = Category.prototype.del = function (query, fn) {
-  var path = '/sites/' + this._sid + '/categories/slug:' + this._slug + '/delete';
-  return this.wpcom.req.del(path, query, fn);
+Category.prototype.delete = Category.prototype.del = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/categories/slug:' + this._slug + '/delete';
+	return this.wpcom.req.del( path, query, fn );
 };
 
 /**

--- a/lib/comment.js
+++ b/lib/comment.js
@@ -1,10 +1,7 @@
-
 /**
  * Module dependencies.
  */
-
-var CommentLike = require('./commentlike');
-var debug = require('debug')('wpcom:comment');
+var CommentLike = require( './commentlike' );
 
 /**
  * Comment methods
@@ -16,19 +13,19 @@ var debug = require('debug')('wpcom:comment');
  * @api public
  */
 
-function Comment(cid, pid, sid, wpcom) {
-  if (!sid) {
-    throw new Error('`site id` is not correctly defined');
-  }
+function Comment( cid, pid, sid, wpcom ) {
+	if ( ! sid ) {
+		throw new Error( '`site id` is not correctly defined' );
+	}
 
-  if (!(this instanceof Comment)) {
-    return new Comment(cid, pid, sid, wpcom);
-  }
+	if ( ! ( this instanceof Comment ) ) {
+		return new Comment( cid, pid, sid, wpcom );
+	}
 
-  this.wpcom = wpcom;
-  this._cid = cid;
-  this._pid = pid;
-  this._sid = sid;
+	this.wpcom = wpcom;
+	this._cid = cid;
+	this._pid = pid;
+	this._sid = sid;
 }
 
 /**
@@ -39,9 +36,9 @@ function Comment(cid, pid, sid, wpcom) {
  * @api public
  */
 
-Comment.prototype.get = function (query, fn) {
-  var path = '/sites/' + this._sid + '/comments/' + this._cid;
-  return this.wpcom.req.get(path, query, fn);
+Comment.prototype.get = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/comments/' + this._cid;
+	return this.wpcom.req.get( path, query, fn );
 };
 
 /**
@@ -52,9 +49,9 @@ Comment.prototype.get = function (query, fn) {
  * @api public
  */
 
-Comment.prototype.replies = function (query, fn) {
-  var path = '/sites/' + this._sid + '/posts/' + this._pid + '/replies/';
-  return this.wpcom.req.get(path, query, fn);
+Comment.prototype.replies = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/posts/' + this._pid + '/replies/';
+	return this.wpcom.req.get( path, query, fn );
 };
 
 /**
@@ -66,22 +63,24 @@ Comment.prototype.replies = function (query, fn) {
  * @api public
  */
 
-Comment.prototype.add = function (query, body, fn) {
-  if ( undefined === fn ) {
-    if ( undefined === body ) {
-      body = query;
-      query = {};
-    } else if ( 'function' === typeof body ) {
-      fn = body;
-      body = query;
-      query = {};
-    }
-  }
+Comment.prototype.add = function( query, body, fn ) {
+	if ( undefined === fn ) {
+		if ( undefined === body ) {
+			body = query;
+			query = {};
+		} else if ( 'function' === typeof body ) {
+			fn = body;
+			body = query;
+			query = {};
+		}
+	}
 
-  body = 'string' === typeof body ? { content: body } : body;
+	body = 'string' === typeof body ? {
+		content: body
+	} : body;
 
-  var path = '/sites/' + this._sid + '/posts/' + this._pid + '/replies/new';
-  return this.wpcom.req.post(path, query, body, fn);
+	let path = '/sites/' + this._sid + '/posts/' + this._pid + '/replies/new';
+	return this.wpcom.req.post( path, query, body, fn );
 };
 
 /**
@@ -93,17 +92,19 @@ Comment.prototype.add = function (query, body, fn) {
  * @api public
  */
 
-Comment.prototype.update = function (query, body, fn) {
-  if ('function' === typeof body) {
-    fn = body;
-    body = query;
-    query = {};
-  }
+Comment.prototype.update = function( query, body, fn ) {
+	if ( 'function' === typeof body ) {
+		fn = body;
+		body = query;
+		query = {};
+	}
 
-  body = 'string' === typeof body ? { content: body } : body;
+	body = 'string' === typeof body ? {
+		content: body
+	} : body;
 
-  var path = '/sites/' + this._sid + '/comments/' + this._cid;
-  return this.wpcom.req.put(path, query, body, fn);
+	let path = '/sites/' + this._sid + '/comments/' + this._cid;
+	return this.wpcom.req.put( path, query, body, fn );
 };
 
 /**
@@ -115,17 +116,19 @@ Comment.prototype.update = function (query, body, fn) {
  * @api public
  */
 
-Comment.prototype.reply = function (query, body, fn) {
-  if ('function' === typeof body) {
-    fn = body;
-    body = query;
-    query = {};
-  }
+Comment.prototype.reply = function( query, body, fn ) {
+	if ( 'function' === typeof body ) {
+		fn = body;
+		body = query;
+		query = {};
+	}
 
-  body = 'string' === typeof body ? { content: body } : body;
+	body = 'string' === typeof body ? {
+		content: body
+	} : body;
 
-  var path = '/sites/' + this._sid + '/comments/' + this._cid + '/replies/new';
-  return this.wpcom.req.post(path, query, body, fn);
+	let path = '/sites/' + this._sid + '/comments/' + this._cid + '/replies/new';
+	return this.wpcom.req.post( path, query, body, fn );
 };
 
 /**
@@ -137,9 +140,9 @@ Comment.prototype.reply = function (query, body, fn) {
  */
 
 Comment.prototype.del =
-Comment.prototype['delete'] = function (query, fn) {
-  var path = '/sites/' + this._sid + '/comments/' + this._cid + '/delete';
-  return this.wpcom.req.del(path, query, fn);
+Comment.prototype.delete = function( query, fn ) {
+	let path = '/sites/' + this._sid + '/comments/' + this._cid + '/delete';
+	return this.wpcom.req.del( path, query, fn );
 };
 
 /**
@@ -149,7 +152,7 @@ Comment.prototype['delete'] = function (query, fn) {
  */
 
 Comment.prototype.like = function() {
-  return CommentLike(this._cid, this._sid, this.wpcom);
+	return CommentLike( this._cid, this._sid, this.wpcom );
 };
 
 /**
@@ -160,9 +163,9 @@ Comment.prototype.like = function() {
  * @api public
  */
 
-Comment.prototype.likesList = function (query, fn) {
-  var path = '/sites/' + this._sid + '/comments/' + this._cid + '/likes';
-  return this.wpcom.req.get(path, query, fn);
+Comment.prototype.likesList = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/comments/' + this._cid + '/likes';
+	return this.wpcom.req.get( path, query, fn );
 };
 
 /**

--- a/lib/commentlike.js
+++ b/lib/commentlike.js
@@ -1,10 +1,3 @@
-
-/**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:commentlike');
-
 /**
  * CommentLike methods
  *
@@ -14,22 +7,22 @@ var debug = require('debug')('wpcom:commentlike');
  * @api public
  */
 
-function CommentLike(cid, sid, wpcom) {
-  if (!sid) {
-    throw new Error('`site id` is not correctly defined');
-  }
+function CommentLike( cid, sid, wpcom ) {
+	if ( ! sid ) {
+		throw new Error( '`site id` is not correctly defined' );
+	}
 
-  if (!cid) {
-    throw new Error('`comment id` is not correctly defined');
-  }
+	if ( ! cid ) {
+		throw new Error( '`comment id` is not correctly defined' );
+	}
 
-  if (!(this instanceof CommentLike)) {
-    return new CommentLike(cid, sid, wpcom);
-  }
+	if ( ! ( this instanceof CommentLike ) ) {
+		return new CommentLike( cid, sid, wpcom );
+	}
 
-  this.wpcom = wpcom;
-  this._cid = cid;
-  this._sid = sid;
+	this.wpcom = wpcom;
+	this._cid = cid;
+	this._sid = sid;
 }
 
 /**
@@ -41,9 +34,9 @@ function CommentLike(cid, sid, wpcom) {
  */
 
 CommentLike.prototype.mine =
-CommentLike.prototype.state = function (query, fn) {
-  var path = '/sites/' + this._sid + '/comments/' + this._cid + '/likes/mine';
-  return this.wpcom.req.get(path, query, fn);
+CommentLike.prototype.state = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/comments/' + this._cid + '/likes/mine';
+	return this.wpcom.req.get( path, query, fn );
 };
 
 /**
@@ -54,9 +47,9 @@ CommentLike.prototype.state = function (query, fn) {
  * @api public
  */
 
-CommentLike.prototype.add = function (query, fn) {
-  var path = '/sites/' + this._sid + '/comments/' + this._cid + '/likes/new';
-  return this.wpcom.req.post(path, query, fn);
+CommentLike.prototype.add = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/comments/' + this._cid + '/likes/new';
+	return this.wpcom.req.post( path, query, fn );
 };
 
 /**
@@ -68,9 +61,9 @@ CommentLike.prototype.add = function (query, fn) {
  */
 
 CommentLike.prototype.del =
-CommentLike.prototype['delete'] = function (query, fn) {
-  var path = '/sites/' + this._sid + '/comments/' + this._cid + '/likes/mine/delete';
-  return this.wpcom.req.del(path, query, fn);
+CommentLike.prototype.delete = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/comments/' + this._cid + '/likes/mine/delete';
+	return this.wpcom.req.del( path, query, fn );
 };
 
 /**

--- a/lib/follow.js
+++ b/lib/follow.js
@@ -1,33 +1,26 @@
-
 /**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:follow');
-
-/**
- * Follow 
+ * Follow
  *
  * @param {String} site_id - site id
  * @param {WPCOM} wpcom
  * @api public
  */
 
-function Follow(site_id, wpcom) {
-  if (!site_id) {
-    throw new Error('`site id` is not correctly defined');
-  }
+function Follow( site_id, wpcom ) {
+	if ( ! site_id ) {
+		throw new Error( '`site id` is not correctly defined' );
+	}
 
-  if (!(this instanceof Follow)) {
-    return new Follow(site_id, wpcom);
-  }
+	if ( ! ( this instanceof Follow ) ) {
+		return new Follow( site_id, wpcom );
+	}
 
-  this.wpcom = wpcom;
-  this._sid = site_id;
+	this.wpcom = wpcom;
+	this._sid = site_id;
 }
 
 /**
- * Get the follow status for current 
+ * Get the follow status for current
  * user on current blog sites
  *
  * @param {Object} [query]
@@ -36,9 +29,9 @@ function Follow(site_id, wpcom) {
  */
 
 Follow.prototype.mine =
-Follow.prototype.state = function (query, fn) {
-  var path = '/sites/' + this._sid + '/follows/mine';
-  return this.wpcom.req.get(path, query, fn);
+Follow.prototype.state = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/follows/mine';
+	return this.wpcom.req.get( path, query, fn );
 };
 
 /**
@@ -50,9 +43,9 @@ Follow.prototype.state = function (query, fn) {
  */
 
 Follow.prototype.follow =
-Follow.prototype.add = function (query, fn) {
-  var path = '/sites/' + this._sid + '/follows/new';
-  return this.wpcom.req.put(path, query, null, fn);
+Follow.prototype.add = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/follows/new';
+	return this.wpcom.req.put( path, query, null, fn );
 };
 
 /**
@@ -64,9 +57,9 @@ Follow.prototype.add = function (query, fn) {
  */
 
 Follow.prototype.unfollow =
-Follow.prototype.del = function (query, fn) {
-  var path = '/sites/' + this._sid + '/follows/mine/delete';
-  return this.wpcom.req.del(path, query, null, fn);
+Follow.prototype.del = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/follows/mine/delete';
+	return this.wpcom.req.del( path, query, null, fn );
 };
 
 /**

--- a/lib/like.js
+++ b/lib/like.js
@@ -1,10 +1,3 @@
-
-/**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:like');
-
 /**
  * Like methods
  *
@@ -14,22 +7,22 @@ var debug = require('debug')('wpcom:like');
  * @api public
  */
 
-function Like(pid, sid, wpcom) {
-  if (!sid) {
-    throw new Error('`site id` is not correctly defined');
-  }
+function Like( pid, sid, wpcom ) {
+	if ( ! sid ) {
+		throw new Error( '`site id` is not correctly defined' );
+	}
 
-  if (!pid) {
-    throw new Error('`post id` is not correctly defined');
-  }
+	if ( ! pid ) {
+		throw new Error( '`post id` is not correctly defined' );
+	}
 
-  if (!(this instanceof Like)) {
-    return new Like(pid, sid, wpcom);
-  }
+	if ( ! ( this instanceof Like ) ) {
+		return new Like( pid, sid, wpcom );
+	}
 
-  this.wpcom = wpcom;
-  this._pid = pid;
-  this._sid = sid;
+	this.wpcom = wpcom;
+	this._pid = pid;
+	this._sid = sid;
 }
 
 /**
@@ -41,9 +34,9 @@ function Like(pid, sid, wpcom) {
  */
 
 Like.prototype.mine =
-Like.prototype.state = function (query, fn) {
-  var path = '/sites/' + this._sid + '/posts/' + this._pid + '/likes/mine';
-  return this.wpcom.req.get(path, query, fn);
+Like.prototype.state = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/posts/' + this._pid + '/likes/mine';
+	return this.wpcom.req.get( path, query, fn );
 };
 
 /**
@@ -54,9 +47,9 @@ Like.prototype.state = function (query, fn) {
  * @api public
  */
 
-Like.prototype.add = function (query, fn) {
-  var path = '/sites/' + this._sid + '/posts/' + this._pid + '/likes/new';
-  return this.wpcom.req.put(path, query, null, fn);
+Like.prototype.add = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/posts/' + this._pid + '/likes/new';
+	return this.wpcom.req.put( path, query, null, fn );
 };
 
 /**
@@ -68,9 +61,9 @@ Like.prototype.add = function (query, fn) {
  */
 
 Like.prototype.del =
-Like.prototype['delete'] = function (query, fn) {
-  var path = '/sites/' + this._sid + '/posts/' + this._pid + '/likes/mine/delete';
-  return this.wpcom.req.del(path, query, fn);
+Like.prototype.delete = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/posts/' + this._pid + '/likes/mine/delete';
+	return this.wpcom.req.del( path, query, fn );
 };
 
 /**

--- a/lib/me.js
+++ b/lib/me.js
@@ -1,10 +1,3 @@
-
-/**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:me');
-
 /**
  * Create a `Me` instance
  *
@@ -12,12 +5,12 @@ var debug = require('debug')('wpcom:me');
  * @api public
  */
 
-function Me(wpcom) {
-  if (!(this instanceof Me)) {
-    return new Me(wpcom);
-  }
+function Me( wpcom ) {
+	if ( ! ( this instanceof Me ) ) {
+		return new Me( wpcom );
+	}
 
-  this.wpcom = wpcom;
+	this.wpcom = wpcom;
 }
 
 /**
@@ -28,8 +21,8 @@ function Me(wpcom) {
  * @api public
  */
 
-Me.prototype.get = function (query, fn) {
-  return this.wpcom.req.get('/me', query, fn);
+Me.prototype.get = function( query, fn ) {
+	return this.wpcom.req.get( '/me', query, fn );
 };
 
 /**
@@ -40,8 +33,8 @@ Me.prototype.get = function (query, fn) {
  * @api private
  */
 
-Me.prototype.sites = function (query, fn) {
-  return this.wpcom.req.get('/me/sites', query, fn);
+Me.prototype.sites = function( query, fn ) {
+	return this.wpcom.req.get( '/me/sites', query, fn );
 };
 
 /**
@@ -52,8 +45,8 @@ Me.prototype.sites = function (query, fn) {
  * @api public
  */
 
-Me.prototype.likes = function (query, fn) {
-  return this.wpcom.req.get('/me/likes', query, fn);
+Me.prototype.likes = function( query, fn ) {
+	return this.wpcom.req.get( '/me/likes', query, fn );
 };
 
 /**
@@ -64,8 +57,8 @@ Me.prototype.likes = function (query, fn) {
  * @api public
  */
 
-Me.prototype.groups = function (query, fn) {
-  return this.wpcom.req.get('/me/groups', query, fn);
+Me.prototype.groups = function( query, fn ) {
+	return this.wpcom.req.get( '/me/groups', query, fn );
 };
 
 /**
@@ -76,8 +69,8 @@ Me.prototype.groups = function (query, fn) {
  * @api public
  */
 
-Me.prototype.connections = function (query, fn) {
-  return this.wpcom.req.get('/me/connections', query, fn);
+Me.prototype.connections = function( query, fn ) {
+	return this.wpcom.req.get( '/me/connections', query, fn );
 };
 
 /**

--- a/lib/media.js
+++ b/lib/media.js
@@ -1,18 +1,8 @@
-
 /**
  * Module dependencies.
  */
-
-var fs = require('fs');
-var debug = require('debug')('wpcom:media');
-
-/**
- * Default
- */
-
-var def = {
-  "apiVersion": "1.1"
-};
+var fs = require( 'fs' );
+var debug = require( 'debug' )( 'wpcom:media' );
 
 /**
  * Media methods
@@ -23,18 +13,18 @@ var def = {
  * @api public
  */
 
-function Media(id, sid, wpcom) {
-  if (!(this instanceof Media)) {
-    return new Media(id, sid, wpcom);
-  }
+function Media( id, sid, wpcom ) {
+	if ( ! ( this instanceof Media ) ) {
+		return new Media( id, sid, wpcom );
+	}
 
-  this.wpcom = wpcom;
-  this._sid = sid;
-  this._id = id;
+	this.wpcom = wpcom;
+	this._sid = sid;
+	this._id = id;
 
-  if (!this._id) {
-    debug('WARN: media `id` is not defined');
-  }
+	if ( ! this._id ) {
+		debug( 'WARN: media `id` is not defined' );
+	}
 }
 
 /**
@@ -45,9 +35,9 @@ function Media(id, sid, wpcom) {
  * @api public
  */
 
-Media.prototype.get = function (query, fn) {
-  var path = '/sites/' + this._sid + '/media/' + this._id;
-  return this.wpcom.req.get(path, query, fn);
+Media.prototype.get = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/media/' + this._id;
+	return this.wpcom.req.get( path, query, fn );
 };
 
 /**
@@ -59,9 +49,9 @@ Media.prototype.get = function (query, fn) {
  * @api public
  */
 
-Media.prototype.update = function (query, body, fn) {
-  var path = '/sites/' + this._sid + '/media/' + this._id;
-  return this.wpcom.req.put(path, query, body, fn);
+Media.prototype.update = function( query, body, fn ) {
+	var path = '/sites/' + this._sid + '/media/' + this._id;
+	return this.wpcom.req.put( path, query, body, fn );
 };
 
 /**
@@ -72,55 +62,62 @@ Media.prototype.update = function (query, body, fn) {
  * @param {Function} fn
  */
 
-Media.prototype.addFiles = function (query, files, fn) {
-  if ( undefined === fn ) {
-    if ( undefined === files ) {
-      files = query;
-      query = {};
-    } else if ( 'function' === typeof files ) {
-      fn = files;
-      files = query;
-      query = {};
-    }
-  }
+Media.prototype.addFiles = function( query, files, fn ) {
+	if ( undefined === fn ) {
+		if ( undefined === files ) {
+			files = query;
+			query = {};
+		} else if ( 'function' === typeof files ) {
+			fn = files;
+			files = query;
+			query = {};
+		}
+	}
 
-  var params = {
-    path: '/sites/' + this._sid + '/media/new',
-    formData: []
-  };
+	let params = {
+		path: '/sites/' + this._sid + '/media/new',
+		formData: []
+	};
 
-  // process formData
-  files = Array.isArray(files) ? files : [files];
+	// process formData
+	files = Array.isArray( files ) ? files : [
+		files
+	];
 
-  var i, f, isStream, isFile, k, param;
-  for (i = 0; i < files.length; i++) {
-    f = files[i];
-    f = 'string' === typeof f ? fs.createReadStream(f) : f;
+	for ( let i = 0; i < files.length; i++ ) {
+		let f = files[ i ];
+		f = 'string' === typeof f ? fs.createReadStream( f ) : f;
 
-    isStream = !!f._readableState;
-    isFile = 'undefined' !== typeof File && f instanceof File;
+		let isStream = !! f._readableState;
+		let isFile = 'undefined' !== typeof File && f instanceof File;
 
-    debug('is stream: %s', isStream);
-    debug('is file: %s', isFile);
+		debug( 'is stream: %s', isStream );
+		debug( 'is file: %s', isFile );
 
-    if (!isFile && !isStream) {
-      // process file attributes like as `title`, `description`, ...
-      for (k in f) {
-        debug('add %o => %o', k, f[k]);
-        if ('file' !== k) {
-          param = 'attrs[' + i + '][' + k + ']';
-          params.formData.push([param, f[k]]);
-        }
-      }
-      // set file path
-      f = f.file;
-      f = 'string' === typeof f ? fs.createReadStream(f) : f;
-    }
+		if ( ! isFile && ! isStream ) {
+			// process file attributes like as `title`, `description`, ...
+			for ( let k in f ) {
+				debug( 'add %o => %o', k, f[ k ] );
+				if ( 'file' !== k ) {
+					let param = 'attrs[' + i + '][' + k + ']';
+					params.formData.push( [
+						param,
+						f[ k ]
+					] );
+				}
+			}
+			// set file path
+			f = f.file;
+			f = 'string' === typeof f ? fs.createReadStream( f ) : f;
+		}
 
-    params.formData.push(['media[]', f]);
-  }
+		params.formData.push( [
+			'media[]',
+			f
+		] );
+	}
 
-  return this.wpcom.req.post(params, query, null, fn);
+	return this.wpcom.req.post( params, query, null, fn );
 };
 
 /**
@@ -131,50 +128,53 @@ Media.prototype.addFiles = function (query, files, fn) {
  * @param {Function} fn
  */
 
-Media.prototype.addUrls = function (query, media, fn) {
-  if ( undefined === fn ) {
-    if ( undefined === media ) {
-      media = query;
-      query = {};
-    } else if ( 'function' === typeof media ) {
-      fn = media;
-      media = query;
-      query = {};
-    }
-  }
+Media.prototype.addUrls = function( query, media, fn ) {
+	if ( undefined === fn ) {
+		if ( undefined === media ) {
+			media = query;
+			query = {};
+		} else if ( 'function' === typeof media ) {
+			fn = media;
+			media = query;
+			query = {};
+		}
+	}
 
-  var path = '/sites/' + this._sid + '/media/new';
-  var body = { media_urls: [] };
+	let path = '/sites/' + this._sid + '/media/new';
+	let body = {
+		media_urls: []
+	};
 
-  // process formData
-  var i, m, url, k;
+	// process formData
+	media = Array.isArray( media ) ? media : [
+		media
+	];
+	for ( let i = 0; i < media.length; i++ ) {
+		let m = media[ i ],
+			k, url;
 
-  media = Array.isArray(media) ? media : [ media ];
-  for (i = 0; i < media.length; i++) {
-    m = media[i];
+		if ( 'string' === typeof m ) {
+			url = m;
+		} else {
+			if ( ! body.attrs ) {
+				body.attrs = [];
+			}
 
-    if ('string' === typeof m) {
-      url = m;
-    } else {
-      if (!body.attrs) {
-        body.attrs = [];
-      }
+			// add attributes
+			body.attrs[ i ] = {};
+			for ( k in m ) {
+				if ( 'url' !== k ) {
+					body.attrs[ i ][ k ] = m[ k ];
+				}
+			}
+			url = m[ k ];
+		}
 
-      // add attributes
-      body.attrs[i] = {};
-      for (k in m) {
-        if ('url' !== k) {
-          body.attrs[i][k] = m[k];
-        }
-      }
-      url = m[k];
-    }
+		// push url into [media_url]
+		body.media_urls.push( url );
+	}
 
-    // push url into [media_url]
-    body.media_urls.push(url);
-  }
-
-  return this.wpcom.req.post(path, query, body, fn);
+	return this.wpcom.req.post( path, query, body, fn );
 };
 
 /**
@@ -185,9 +185,9 @@ Media.prototype.addUrls = function (query, media, fn) {
  * @api public
  */
 
-Media.prototype['delete'] = Media.prototype.del = function (query, fn) {
-  var path = '/sites/' + this._sid + '/media/' + this._id + '/delete';
-  return this.wpcom.req.del(path, query, fn);
+Media.prototype.delete = Media.prototype.del = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/media/' + this._id + '/delete';
+	return this.wpcom.req.del( path, query, fn );
 };
 
 /**

--- a/lib/post.js
+++ b/lib/post.js
@@ -1,12 +1,10 @@
-
 /**
  * Module dependencies.
  */
-
-var Like = require('./like');
-var Reblog = require('./reblog');
-var Comment = require('./comment');
-var debug = require('debug')('wpcom:post');
+var Like = require( './like' );
+var Reblog = require( './reblog' );
+var Comment = require( './comment' );
+var debug = require( 'debug' )( 'wpcom:post' );
 
 /**
  * Post methods
@@ -17,22 +15,22 @@ var debug = require('debug')('wpcom:post');
  * @api public
  */
 
-function Post(id, sid, wpcom) {
-  if (!(this instanceof Post)) {
-    return new Post(id, sid, wpcom);
-  }
+function Post( id, sid, wpcom ) {
+	if ( ! ( this instanceof Post ) ) {
+		return new Post( id, sid, wpcom );
+	}
 
-  this.wpcom = wpcom;
-  this._sid = sid;
+	this.wpcom = wpcom;
+	this._sid = sid;
 
-  // set `id` and/or `slug` properties
-  id = id || {};
-  if ('object' !== typeof id) {
-    this._id = id;
-  } else {
-    this._id = id.id;
-    this._slug = id.slug;
-  }
+	// set `id` and/or `slug` properties
+	id = id || {};
+	if ( 'object' !== typeof id ) {
+		this._id = id;
+	} else {
+		this._id = id.id;
+		this._slug = id.slug;
+	}
 }
 
 /**
@@ -42,8 +40,8 @@ function Post(id, sid, wpcom) {
  * @api public
  */
 
-Post.prototype.id = function (id) {
-  this._id = id;
+Post.prototype.id = function( id ) {
+	this._id = id;
 };
 
 /**
@@ -53,8 +51,8 @@ Post.prototype.id = function (id) {
  * @api public
  */
 
-Post.prototype.slug = function (slug) {
-  this._slug = slug;
+Post.prototype.slug = function( slug ) {
+	this._slug = slug;
 };
 
 /**
@@ -65,13 +63,13 @@ Post.prototype.slug = function (slug) {
  * @api public
  */
 
-Post.prototype.get = function (query, fn) {
-  if (!this._id && this._slug) {
-    return this.getBySlug(query, fn);
-  }
+Post.prototype.get = function( query, fn ) {
+	if ( ! this._id && this._slug ) {
+		return this.getBySlug( query, fn );
+	}
 
-  var path = '/sites/' + this._sid + '/posts/' + this._id;
-  return this.wpcom.req.get(path, query, fn);
+	let path = '/sites/' + this._sid + '/posts/' + this._id;
+	return this.wpcom.req.get( path, query, fn );
 };
 
 /**
@@ -82,9 +80,9 @@ Post.prototype.get = function (query, fn) {
  * @api public
  */
 
-Post.prototype.getBySlug = function (query, fn) {
-  var path = '/sites/' + this._sid + '/posts/slug:' + this._slug;
-  return this.wpcom.req.get(path, query, fn);
+Post.prototype.getBySlug = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/posts/slug:' + this._slug;
+	return this.wpcom.req.get( path, query, fn );
 };
 
 /**
@@ -96,42 +94,42 @@ Post.prototype.getBySlug = function (query, fn) {
  * @api public
  */
 
-Post.prototype.add = function (query, body, fn) {
-  if ( undefined === fn ) {
-    if ( undefined === body ) {
-      body = query;
-      query = {};
-    } else if ( 'function' === typeof body ) {
-      fn = body;
-      body = query;
-      query = {};
-    }
-  }
+Post.prototype.add = function( query, body, fn ) {
+	if ( undefined === fn ) {
+		if ( undefined === body ) {
+			body = query;
+			query = {};
+		} else if ( 'function' === typeof body ) {
+			fn = body;
+			body = query;
+			query = {};
+		}
+	}
 
-  var path = '/sites/' + this._sid + '/posts/new';
+	let path = '/sites/' + this._sid + '/posts/new';
 
-  return this.wpcom.req.post(path, query, body)
-    .then(data => {
-      // update POST object
-      this._id = data.ID;
-      debug('Set post _id: %s', this._id);
+	return this.wpcom.req.post( path, query, body )
+		.then( data => {
+			// update POST object
+			this._id = data.ID;
+			debug( 'Set post _id: %s', this._id );
 
-      this._slug = data.slug;
-      debug('Set post _slug: %s', this._slug);
+			this._slug = data.slug;
+			debug( 'Set post _slug: %s', this._slug );
 
-      if ( 'function' === typeof fn ) {
-        fn(null, data);
-      } else {
-        return Promise.resolve( data );
-      }
-    })
-    .catch(err => {
-      if ( 'function' === typeof fn ) {
-        fn(err);
-      } else {
-        return Promise.reject( error );
-      }
-    });
+			if ( 'function' === typeof fn ) {
+				fn( null, data );
+			} else {
+				return Promise.resolve( data );
+			}
+		} )
+		.catch( err => {
+			if ( 'function' === typeof fn ) {
+				fn( err );
+			} else {
+				return Promise.reject( error );
+			}
+		} );
 };
 
 /**
@@ -143,9 +141,9 @@ Post.prototype.add = function (query, body, fn) {
  * @api public
  */
 
-Post.prototype.update = function (query, body, fn) {
-  var path = '/sites/' + this._sid + '/posts/' + this._id;
-  return this.wpcom.req.put(path, query, body, fn);
+Post.prototype.update = function( query, body, fn ) {
+	var path = '/sites/' + this._sid + '/posts/' + this._id;
+	return this.wpcom.req.put( path, query, body, fn );
 };
 
 /**
@@ -157,9 +155,9 @@ Post.prototype.update = function (query, body, fn) {
  */
 
 Post.prototype.del =
-Post.prototype['delete'] = function (query, fn) {
-  var path = '/sites/' + this._sid + '/posts/' + this._id + '/delete';
-  return this.wpcom.req.del(path, query, fn);
+Post.prototype.delete = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/posts/' + this._id + '/delete';
+	return this.wpcom.req.del( path, query, fn );
 };
 
 /**
@@ -170,9 +168,9 @@ Post.prototype['delete'] = function (query, fn) {
  * @api public
  */
 
-Post.prototype.restore = function (query, fn) {
-  var path = '/sites/' + this._sid + '/posts/' + this._id + '/restore';
-  return this.wpcom.req.put(path, query, null, fn);
+Post.prototype.restore = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/posts/' + this._id + '/restore';
+	return this.wpcom.req.put( path, query, null, fn );
 };
 
 /**
@@ -183,9 +181,9 @@ Post.prototype.restore = function (query, fn) {
  * @api public
  */
 
-Post.prototype.likesList = function (query, fn) {
-  var path = '/sites/' + this._sid + '/posts/' + this._id + '/likes';
-  return this.wpcom.req.get(path, query, fn);
+Post.prototype.likesList = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/posts/' + this._id + '/likes';
+	return this.wpcom.req.get( path, query, fn );
 };
 
 /**
@@ -196,9 +194,9 @@ Post.prototype.likesList = function (query, fn) {
  * @api public
  */
 
-Post.prototype.related = function (body, fn) {
-  var path = '/sites/' + this._sid + '/posts/' + this._id + '/related';
-  return this.wpcom.req.put(path, body, null, fn);
+Post.prototype.related = function( body, fn ) {
+	var path = '/sites/' + this._sid + '/posts/' + this._id + '/related';
+	return this.wpcom.req.put( path, body, null, fn );
 };
 
 /**
@@ -207,8 +205,8 @@ Post.prototype.related = function (body, fn) {
  * @api public
  */
 
-Post.prototype.like = function () {
-  return new Like(this._id, this._sid, this.wpcom);
+Post.prototype.like = function() {
+	return new Like( this._id, this._sid, this.wpcom );
 };
 
 /**
@@ -217,8 +215,8 @@ Post.prototype.like = function () {
  * @api public
  */
 
-Post.prototype.reblog = function () {
-  return new Reblog(this._id, this._sid, this.wpcom);
+Post.prototype.reblog = function() {
+	return new Reblog( this._id, this._sid, this.wpcom );
 };
 
 /**
@@ -228,8 +226,8 @@ Post.prototype.reblog = function () {
  * @api public
  */
 
-Post.prototype.comment = function (cid) {
-  return new Comment(cid, this._id, this._sid, this.wpcom);
+Post.prototype.comment = function( cid ) {
+	return new Comment( cid, this._id, this._sid, this.wpcom );
 };
 
 /**
@@ -240,9 +238,9 @@ Post.prototype.comment = function (cid) {
  * @api public
  */
 
-Post.prototype.comments = function (query, fn) {
-  var comment = new Comment(null, this._id, this._sid, this.wpcom);
-  return comment.replies(query, fn);
+Post.prototype.comments = function( query, fn ) {
+	var comment = new Comment( null, this._id, this._sid, this.wpcom );
+	return comment.replies( query, fn );
 };
 
 /**

--- a/lib/reblog.js
+++ b/lib/reblog.js
@@ -1,10 +1,3 @@
-
-/**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:reblog');
-
 /**
  * Reblog methods
  *
@@ -14,22 +7,22 @@ var debug = require('debug')('wpcom:reblog');
  * @api public
  */
 
-function Reblog(pid, sid, wpcom) {
-  if (!sid) {
-    throw new Error('`site id` is not correctly defined');
-  }
+function Reblog( pid, sid, wpcom ) {
+	if ( ! sid ) {
+		throw new Error( '`site id` is not correctly defined' );
+	}
 
-  if (!pid) {
-    throw new Error('`post id` is not correctly defined');
-  }
+	if ( ! pid ) {
+		throw new Error( '`post id` is not correctly defined' );
+	}
 
-  if (!(this instanceof Reblog)) {
-    return new Reblog(pid, sid, wpcom);
-  }
+	if ( ! ( this instanceof Reblog ) ) {
+		return new Reblog( pid, sid, wpcom );
+	}
 
-  this.wpcom = wpcom;
-  this._pid = pid;
-  this._sid = sid;
+	this.wpcom = wpcom;
+	this._pid = pid;
+	this._sid = sid;
 }
 
 /**
@@ -41,9 +34,9 @@ function Reblog(pid, sid, wpcom) {
  */
 
 Reblog.prototype.mine =
-Reblog.prototype.state = function (query, fn) {
-  var path = '/sites/' + this._sid + '/posts/' + this._pid + '/reblogs/mine';
-  return this.wpcom.req.get(path, query, fn);
+Reblog.prototype.state = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/posts/' + this._pid + '/reblogs/mine';
+	return this.wpcom.req.get( path, query, fn );
 };
 
 /**
@@ -55,19 +48,19 @@ Reblog.prototype.state = function (query, fn) {
  * @api public
  */
 
-Reblog.prototype.add = function (query, body, fn) {
-  if ('function' === typeof body) {
-    fn = body;
-    body = query;
-    query = {};
-  }
+Reblog.prototype.add = function( query, body, fn ) {
+	if ( 'function' === typeof body ) {
+		fn = body;
+		body = query;
+		query = {};
+	}
 
-  if (body && !body.destination_site_id) {
-    return fn(new Error('destination_site_id is not defined'));
-  }
+	if ( body && ! body.destination_site_id ) {
+		return fn( new Error( 'destination_site_id is not defined' ) );
+	}
 
-  var path = '/sites/' + this._sid + '/posts/' + this._pid + '/reblogs/new';
-  return this.wpcom.req.put(path, query, body, fn);
+	let path = '/sites/' + this._sid + '/posts/' + this._pid + '/reblogs/new';
+	return this.wpcom.req.put( path, query, body, fn );
 };
 
 /**
@@ -80,17 +73,20 @@ Reblog.prototype.add = function (query, body, fn) {
  * @api public
  */
 
-Reblog.prototype.to = function (dest, note, fn) {
-  if ( undefined === fn ) {
-    if ( undefined === note ) {
-      note = null;
-    } else if ('function' === typeof note) {
-      fn = note;
-      note = null;
-    }
-  }
+Reblog.prototype.to = function( dest, note, fn ) {
+	if ( undefined === fn ) {
+		if ( undefined === note ) {
+			note = null;
+		} else if ( 'function' === typeof note ) {
+			fn = note;
+			note = null;
+		}
+	}
 
-  return this.add({ note: note, destination_site_id: dest }, fn);
+	return this.add( {
+		note: note,
+		destination_site_id: dest
+	}, fn );
 };
 
 /**

--- a/lib/site.js
+++ b/lib/site.js
@@ -1,48 +1,96 @@
-
 /**
  * Module dependencies.
  */
-
-var Post = require('./post');
-var Category = require('./category');
-var Tag = require('./tag');
-var Media = require('./media');
-var Comment = require('./comment');
-var Follow = require('./follow');
-var debug = require('debug')('wpcom:site');
+var Post = require( './post' );
+var Category = require( './category' );
+var Tag = require( './tag' );
+var Media = require( './media' );
+var Comment = require( './comment' );
+var Follow = require( './follow' );
+var debug = require( 'debug' )( 'wpcom:site' );
 
 /**
  * Resources array
  * A list of endpoints with the same structure
  */
-
 var resources = [
-  'categories',
-  'comments',
-  'follows',
-  'media',
-  'posts',
-  'shortcodes',
-  'embeds',
-  [ 'pageTemplates', 'page-templates' ],
-  [ 'stats', 'stats' ],
-  [ 'statsClicks', 'stats/clicks' ],
-  [ 'statsComments', 'stats/comments' ],
-  [ 'statsCommentFollowers', 'stats/comment-followers' ],
-  [ 'statsCountryViews', 'stats/country-views' ],
-  [ 'statsFollowers', 'stats/followers' ],
-  [ 'statsPublicize', 'stats/publicize' ],
-  [ 'statsReferrers', 'stats/referrers' ],
-  [ 'statsSearchTerms', 'stats/search-terms' ],
-  [ 'statsStreak', 'stats/streak' ],
-  [ 'statsSummary', 'stats/summary' ],
-  [ 'statsTags', 'stats/tags' ],
-  [ 'statsTopAuthors', 'stats/top-authors' ],
-  [ 'statsTopPosts', 'stats/top-posts' ],
-  [ 'statsVideoPlays', 'stats/video-plays' ],
-  [ 'statsVisits', 'stats/visits' ],
-  'tags',
-  'users'
+	'categories',
+	'comments',
+	'follows',
+	'media',
+	'posts',
+	'shortcodes',
+	'embeds',
+	[
+		'pageTemplates',
+		'page-templates'
+	],
+	[
+		'stats',
+		'stats'
+	],
+	[
+		'statsClicks',
+		'stats/clicks'
+	],
+	[
+		'statsComments',
+		'stats/comments'
+	],
+	[
+		'statsCommentFollowers',
+		'stats/comment-followers'
+	],
+	[
+		'statsCountryViews',
+		'stats/country-views'
+	],
+	[
+		'statsFollowers',
+		'stats/followers'
+	],
+	[
+		'statsPublicize',
+		'stats/publicize'
+	],
+	[
+		'statsReferrers',
+		'stats/referrers'
+	],
+	[
+		'statsSearchTerms',
+		'stats/search-terms'
+	],
+	[
+		'statsStreak',
+		'stats/streak'
+	],
+	[
+		'statsSummary',
+		'stats/summary'
+	],
+	[
+		'statsTags',
+		'stats/tags'
+	],
+	[
+		'statsTopAuthors',
+		'stats/top-authors'
+	],
+	[
+		'statsTopPosts',
+		'stats/top-posts'
+	],
+	[
+		'statsVideoPlays',
+		'stats/video-plays'
+	],
+	[
+		'statsVisits',
+		'stats/visits'
+	],
+	'tags',
+	'users'
 ];
 
 /**
@@ -52,15 +100,15 @@ var resources = [
  * @api public
  */
 
-function Site(id, wpcom) {
-  if (!(this instanceof Site)) {
-    return new Site(id, wpcom);
-  }
+function Site( id, wpcom ) {
+	if ( ! ( this instanceof Site ) ) {
+		return new Site( id, wpcom );
+	}
 
-  this.wpcom = wpcom;
+	this.wpcom = wpcom;
 
-  debug('set %o site id', id);
-  this._id = encodeURIComponent(id);
+	debug( 'set %o site id', id );
+	this._id = encodeURIComponent( id );
 }
 
 /**
@@ -71,8 +119,8 @@ function Site(id, wpcom) {
  * @api public
  */
 
-Site.prototype.get = function (query, fn) {
-  return this.wpcom.req.get('/sites/' + this._id, query, fn);
+Site.prototype.get = function( query, fn ) {
+	return this.wpcom.req.get( '/sites/' + this._id, query, fn );
 };
 
 /**
@@ -83,35 +131,33 @@ Site.prototype.get = function (query, fn) {
  * @api private
  */
 
-function list(subpath) {
+function list( subpath ) {
+	/**
+	 * Create and return the <names>List method
+	 *
+	 * @param {Object} [query]
+	 * @param {Function} fn
+	 * @api public
+	 */
 
-  /**
-   * Create and return the <names>List method
-   *
-   * @param {Object} [query]
-   * @param {Function} fn
-   * @api public
-   */
-
-  var listMethod = function (query, fn) {
-    var path = '/sites/' + this._id + '/' + subpath;
-    return this.wpcom.req.get(path, query, fn);
-  };
-  listMethod._publicAPI = true;
-  return listMethod;
+	var listMethod = function( query, fn ) {
+		var path = '/sites/' + this._id + '/' + subpath;
+		return this.wpcom.req.get( path, query, fn );
+	};
+	listMethod._publicAPI = true;
+	return listMethod;
 }
 
 // walk for each resource and create related method
-var i, res, isarr, name, subpath;
-for (i = 0; i < resources.length; i++) {
-  res = resources[i];
-  isarr = Array.isArray(res);
+for ( let i = 0; i < resources.length; i++ ) {
+	let res = resources[ i ];
+	let isarr = Array.isArray( res );
 
-  name =  isarr ? res[0] : res + 'List';
-  subpath = isarr ? res[1] : res;
+	let name = isarr ? res[ 0 ] : res + 'List';
+	let subpath = isarr ? res[ 1 ] : res;
 
-  debug('adding method: %o - sub-path: %o - version: %s', ('site.' + name + '()'), subpath);
-  Site.prototype[name] = list(subpath);
+	debug( 'adding method: %o - sub-path: %o - version: %s', ( 'site.' + name + '()' ), subpath );
+	Site.prototype[ name ] = list( subpath );
 }
 
 /**
@@ -122,8 +168,8 @@ for (i = 0; i < resources.length; i++) {
  * @api public
  */
 
-Site.prototype.post = function (id) {
-  return new Post(id, this._id, this.wpcom);
+Site.prototype.post = function( id ) {
+	return new Post( id, this._id, this.wpcom );
 };
 
 /**
@@ -135,9 +181,9 @@ Site.prototype.post = function (id) {
  * @return {Post} new Post instance
  */
 
-Site.prototype.addPost = function (body, fn) {
-  var post = new Post(null, this._id, this.wpcom);
-  return post.add(body, fn);
+Site.prototype.addPost = function( body, fn ) {
+	var post = new Post( null, this._id, this.wpcom );
+	return post.add( body, fn );
 };
 
 /**
@@ -149,9 +195,9 @@ Site.prototype.addPost = function (body, fn) {
  * @return {Post} remove Post instance
  */
 
-Site.prototype.deletePost = function (id, fn) {
-  var post = new Post(id, this._id, this.wpcom);
-  return post.delete(fn);
+Site.prototype.deletePost = function( id, fn ) {
+	var post = new Post( id, this._id, this.wpcom );
+	return post.delete( fn );
 };
 
 /**
@@ -161,8 +207,8 @@ Site.prototype.deletePost = function (id, fn) {
  * @api public
  */
 
-Site.prototype.media = function (id) {
-  return new Media(id, this._id, this.wpcom);
+Site.prototype.media = function( id ) {
+	return new Media( id, this._id, this.wpcom );
 };
 
 /**
@@ -174,9 +220,9 @@ Site.prototype.media = function (id) {
  * @return {Post} new Post instance
  */
 
-Site.prototype.addMediaFiles = function (query, files, fn) {
-  var media = new Media(null, this._id, this.wpcom);
-  return media.addFiles(query, files, fn);
+Site.prototype.addMediaFiles = function( query, files, fn ) {
+	var media = new Media( null, this._id, this.wpcom );
+	return media.addFiles( query, files, fn );
 };
 
 /**
@@ -188,9 +234,9 @@ Site.prototype.addMediaFiles = function (query, files, fn) {
  * @return {Post} new Post instance
  */
 
-Site.prototype.addMediaUrls = function (query, files, fn) {
-  var media = new Media(null, this._id, this.wpcom);
-  return media.addUrls(query, files, fn);
+Site.prototype.addMediaUrls = function( query, files, fn ) {
+	var media = new Media( null, this._id, this.wpcom );
+	return media.addUrls( query, files, fn );
 };
 
 /**
@@ -201,9 +247,9 @@ Site.prototype.addMediaUrls = function (query, files, fn) {
  * @return {Post} removed Media instance
  */
 
-Site.prototype.deleteMedia = function (id, fn) {
-  var media = new Media(id, this._id, this.wpcom);
-  return media.del(fn);
+Site.prototype.deleteMedia = function( id, fn ) {
+	var media = new Media( id, this._id, this.wpcom );
+	return media.del( fn );
 };
 
 /**
@@ -213,8 +259,8 @@ Site.prototype.deleteMedia = function (id, fn) {
  * @api public
  */
 
-Site.prototype.comment = function (id) {
-  return new Comment(id, null, this._id, this.wpcom);
+Site.prototype.comment = function( id ) {
+	return new Comment( id, null, this._id, this.wpcom );
 };
 
 /**
@@ -223,8 +269,8 @@ Site.prototype.comment = function (id) {
  * @api public
  */
 
-Site.prototype.follow = function () {
-  return new Follow(this._id, this.wpcom);
+Site.prototype.follow = function() {
+	return new Follow( this._id, this.wpcom );
 };
 
 /**
@@ -235,8 +281,8 @@ Site.prototype.follow = function () {
  * @api public
  */
 
-Site.prototype.cat = Site.prototype.category = function (slug) {
-  return new Category(slug, this._id, this.wpcom);
+Site.prototype.cat = Site.prototype.category = function( slug ) {
+	return new Category( slug, this._id, this.wpcom );
 };
 
 /**
@@ -246,8 +292,8 @@ Site.prototype.cat = Site.prototype.category = function (slug) {
  * @api public
  */
 
-Site.prototype.tag = function (slug) {
-  return new Tag(slug, this._id, this.wpcom);
+Site.prototype.tag = function( slug ) {
+	return new Tag( slug, this._id, this.wpcom );
 };
 
 /**
@@ -261,22 +307,22 @@ Site.prototype.tag = function (slug) {
  * @api public
  */
 
-Site.prototype.renderShortcode = function (url, query, fn) {
-  if ('string' !== typeof url) {
-    throw new TypeError('expected a url String');
-  }
+Site.prototype.renderShortcode = function( url, query, fn ) {
+	if ( 'string' !== typeof url ) {
+		throw new TypeError( 'expected a url String' );
+	}
 
-  if ('function' == typeof query) {
-    fn = query;
-    query = {};
-  }
+	if ( 'function' === typeof query ) {
+		fn = query;
+		query = {};
+	}
 
-  query = query || {};
-  query.shortcode = url;
+	query = query || {};
+	query.shortcode = url;
 
-  var path = '/sites/' + this._id + '/shortcodes/render';
+	let path = '/sites/' + this._id + '/shortcodes/render';
 
-  return this.wpcom.req.get(path, query, fn);
+	return this.wpcom.req.get( path, query, fn );
 };
 
 /**
@@ -290,21 +336,21 @@ Site.prototype.renderShortcode = function (url, query, fn) {
  * @api public
  */
 
-Site.prototype.renderEmbed = function (url, query, fn) {
-  if ('string' !== typeof url) {
-    throw new TypeError('expected an embed String');
-  }
+Site.prototype.renderEmbed = function( url, query, fn ) {
+	if ( 'string' !== typeof url ) {
+		throw new TypeError( 'expected an embed String' );
+	}
 
-  if ('function' == typeof query) {
-    fn = query;
-    query = {};
-  }
+	if ( 'function' === typeof query ) {
+		fn = query;
+		query = {};
+	}
 
-  query = query || {};
-  query.embed_url = url;
+	query = query || {};
+	query.embed_url = url;
 
-  var path = '/sites/' + this._id + '/embeds/render';
-  return this.wpcom.req.get(path, query, fn);
+	let path = '/sites/' + this._id + '/embeds/render';
+	return this.wpcom.req.get( path, query, fn );
 };
 
 /**
@@ -315,11 +361,13 @@ Site.prototype.renderEmbed = function (url, query, fn) {
  * @api public
  */
 
-Site.prototype.statsReferrersSpamNew = function (domain, fn) {
-  var path = '/sites/' + this._id + '/stats/referrers/spam/new';
-  var body = { domain: domain };
+Site.prototype.statsReferrersSpamNew = function( domain, fn ) {
+	var path = '/sites/' + this._id + '/stats/referrers/spam/new';
+	var body = {
+		domain: domain
+	};
 
-  return this.wpcom.req.post(path, body, null, fn);
+	return this.wpcom.req.post( path, body, null, fn );
 };
 
 /**
@@ -330,11 +378,13 @@ Site.prototype.statsReferrersSpamNew = function (domain, fn) {
  * @api public
  */
 
-Site.prototype.statsReferrersSpamDelete = function (domain, fn) {
-  var path = '/sites/' + this._id + '/stats/referrers/spam/delete';
-  var body = { domain: domain };
+Site.prototype.statsReferrersSpamDelete = function( domain, fn ) {
+	var path = '/sites/' + this._id + '/stats/referrers/spam/delete';
+	var body = {
+		domain: domain
+	};
 
-  return this.wpcom.req.post(path, body, null, fn);
+	return this.wpcom.req.post( path, body, null, fn );
 };
 
 /**
@@ -346,15 +396,15 @@ Site.prototype.statsReferrersSpamDelete = function (domain, fn) {
  * @api public
  */
 
-Site.prototype.statsVideo = function (videoId, query, fn) {
-  var path = '/sites/' + this._id + '/stats/video/' + videoId;
+Site.prototype.statsVideo = function( videoId, query, fn ) {
+	var path = '/sites/' + this._id + '/stats/video/' + videoId;
 
-  if ('function' == typeof query) {
-    fn = query;
-    query = {};
-  }
+	if ( 'function' === typeof query ) {
+		fn = query;
+		query = {};
+	}
 
-  return this.wpcom.req.get(path, query, fn);
+	return this.wpcom.req.get( path, query, fn );
 };
 
 /**
@@ -366,15 +416,15 @@ Site.prototype.statsVideo = function (videoId, query, fn) {
  * @api public
  */
 
-Site.prototype.statsPostViews = function (postId, query, fn) {
-  var path = '/sites/' + this._id + '/stats/post/' + postId;
+Site.prototype.statsPostViews = function( postId, query, fn ) {
+	var path = '/sites/' + this._id + '/stats/post/' + postId;
 
-  if ('function' == typeof query) {
-    fn = query;
-    query = {};
-  }
+	if ( 'function' === typeof query ) {
+		fn = query;
+		query = {};
+	}
 
-  return this.wpcom.req.get(path, query, fn);
+	return this.wpcom.req.get( path, query, fn );
 };
 
 /**

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -1,10 +1,3 @@
-
-/**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:tag');
-
 /**
  * Tag methods
  *
@@ -14,18 +7,18 @@ var debug = require('debug')('wpcom:tag');
  * @api public
  */
 
-function Tag(slug, sid, wpcom) {
-  if (!sid) {
-    throw new Error('`site id` is not correctly defined');
-  }
+function Tag( slug, sid, wpcom ) {
+	if ( ! sid ) {
+		throw new Error( '`site id` is not correctly defined' );
+	}
 
-  if (!(this instanceof Tag)) {
-    return new Tag(slug, sid, wpcom);
-  }
+	if ( ! ( this instanceof Tag ) ) {
+		return new Tag( slug, sid, wpcom );
+	}
 
-  this.wpcom = wpcom;
-  this._sid = sid;
-  this._slug = slug;
+	this.wpcom = wpcom;
+	this._sid = sid;
+	this._slug = slug;
 }
 
 /**
@@ -35,8 +28,8 @@ function Tag(slug, sid, wpcom) {
  * @api public
  */
 
-Tag.prototype.slug = function (slug) {
-  this._slug = slug;
+Tag.prototype.slug = function( slug ) {
+	this._slug = slug;
 };
 
 /**
@@ -47,9 +40,9 @@ Tag.prototype.slug = function (slug) {
  * @api public
  */
 
-Tag.prototype.get = function (query, fn) {
-  var path = '/sites/' + this._sid + '/tags/slug:' + this._slug;
-  return this.wpcom.req.get(path, query, fn);
+Tag.prototype.get = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/tags/slug:' + this._slug;
+	return this.wpcom.req.get( path, query, fn );
 };
 
 /**
@@ -61,9 +54,9 @@ Tag.prototype.get = function (query, fn) {
  * @api public
  */
 
-Tag.prototype.add = function (query, body, fn) {
-  var path = '/sites/' + this._sid + '/tags/new';
-  return this.wpcom.req.post(path, query, body, fn);
+Tag.prototype.add = function( query, body, fn ) {
+	var path = '/sites/' + this._sid + '/tags/new';
+	return this.wpcom.req.post( path, query, body, fn );
 };
 
 /**
@@ -75,9 +68,9 @@ Tag.prototype.add = function (query, body, fn) {
  * @api public
  */
 
-Tag.prototype.update = function (query, body, fn) {
-  var path = '/sites/' + this._sid + '/tags/slug:' + this._slug;
-  return this.wpcom.req.put(path, query, body, fn);
+Tag.prototype.update = function( query, body, fn ) {
+	var path = '/sites/' + this._sid + '/tags/slug:' + this._slug;
+	return this.wpcom.req.put( path, query, body, fn );
 };
 
 /**
@@ -88,9 +81,9 @@ Tag.prototype.update = function (query, body, fn) {
  * @api public
  */
 
-Tag.prototype['delete'] = Tag.prototype.del = function (query, fn) {
-  var path = '/sites/' + this._sid + '/tags/slug:' + this._slug + '/delete';
-  return this.wpcom.req.del(path, query, fn);
+Tag.prototype.delete = Tag.prototype.del = function( query, fn ) {
+	var path = '/sites/' + this._sid + '/tags/slug:' + this._slug + '/delete';
+	return this.wpcom.req.del( path, query, fn );
 };
 
 /**

--- a/lib/users.js
+++ b/lib/users.js
@@ -1,10 +1,3 @@
-
-/**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:users');
-
 /**
  * Create a `Users` instance
  *
@@ -12,12 +5,12 @@ var debug = require('debug')('wpcom:users');
  * @api public
  */
 
-function Users(wpcom) {
-  if (!(this instanceof Users)) {
-    return new Users(wpcom);
-  }
+function Users( wpcom ) {
+	if ( ! ( this instanceof Users ) ) {
+		return new Users( wpcom );
+	}
 
-  this.wpcom = wpcom;
+	this.wpcom = wpcom;
 }
 
 /**
@@ -28,8 +21,8 @@ function Users(wpcom) {
  * @api public
  */
 
-Users.prototype.suggest = function (query, fn) {
-  return this.wpcom.req.get('/users/suggest', query, fn);
+Users.prototype.suggest = function( query, fn ) {
+	return this.wpcom.req.get( '/users/suggest', query, fn );
 };
 
 /**

--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -1,18 +1,14 @@
-
 /**
  * Module dependencies.
  */
-
-var sendRequest = require('./send-request');
-var debug = require('debug')('wpcom:request');
+var sendRequest = require( './send-request' );
 
 /**
  * Expose `Request` module
  */
 
-
-function Req(wpcom) {
-  this.wpcom = wpcom;
+function Req( wpcom ) {
+	this.wpcom = wpcom;
 }
 
 /**
@@ -24,14 +20,14 @@ function Req(wpcom) {
  * @api public
  */
 
-Req.prototype.get = function (params, query, fn) {
-  // `query` is optional
-  if ('function' == typeof query) {
-    fn = query;
-    query = {};
-  }
+Req.prototype.get = function( params, query, fn ) {
+	// `query` is optional
+	if ( 'function' === typeof query ) {
+		fn = query;
+		query = {};
+	}
 
-  return sendRequest.call(this.wpcom, params, query, null, fn);
+	return sendRequest.call( this.wpcom, params, query, null, fn );
 };
 
 /**
@@ -45,25 +41,27 @@ Req.prototype.get = function (params, query, fn) {
  */
 
 Req.prototype.post =
-Req.prototype.put = function (params, query, body, fn) {
-  if (undefined === fn) {
-    if (undefined === body) {
-      body = query;
-      query = {}
-    } else if ( 'function' === typeof body) {
-      fn = body;
-      body = query;
-      query = {};
-    }
-  }
+Req.prototype.put = function( params, query, body, fn ) {
+	if ( undefined === fn ) {
+		if ( undefined === body ) {
+			body = query;
+			query = {};
+		} else if ( 'function' === typeof body ) {
+			fn = body;
+			body = query;
+			query = {};
+		}
+	}
 
-  // params can be a string
-  params = 'string' === typeof params ? { path : params } : params;
+	// params can be a string
+	params = 'string' === typeof params ? {
+		path: params
+	} : params;
 
-  // request method
-  params.method = 'post';
+	// request method
+	params.method = 'post';
 
-  return sendRequest.call(this.wpcom, params, query, body, fn);
+	return sendRequest.call( this.wpcom, params, query, body, fn );
 };
 
 /**
@@ -75,13 +73,13 @@ Req.prototype.put = function (params, query, body, fn) {
  * @api public
  */
 
-Req.prototype.del = function (params, query, fn) {
-  if ('function' == typeof query) {
-    fn = query;
-    query = {};
-  }
+Req.prototype.del = function( params, query, fn ) {
+	if ( 'function' === typeof query ) {
+		fn = query;
+		query = {};
+	}
 
-  return this.post(params, query, null, fn);
+	return this.post( params, query, null, fn );
 };
 
 /**

--- a/lib/util/send-request.js
+++ b/lib/util/send-request.js
@@ -1,11 +1,9 @@
-
 /**
  * Module dependencies
  */
-
-var qs = require('qs');
-var debug = require('debug')('wpcom:send-request');
-var debug_res = require('debug')('wpcom:send-request:res');
+var qs = require( 'qs' );
+var debug = require( 'debug' )( 'wpcom:send-request' );
+var debug_res = require( 'debug' )( 'wpcom:send-request:res' );
 
 /**
  * Request to WordPress REST API
@@ -17,72 +15,76 @@ var debug_res = require('debug')('wpcom:send-request:res');
  * @api private
  */
 
-module.exports = function (params, query, body, fn) {
-  // `params` can be just the path (String)
-  params = 'string' === typeof params ? { path : params } : params;
+module.exports = function( params, query, body, fn ) {
+	// `params` can be just the path (String)
+	params = 'string' === typeof params ? {
+		path: params
+	} : params;
 
-  debug('sendRequest(%o)', params.path);
+	debug( 'sendRequest(%o)', params.path );
 
-  // set `method` request param
-  params.method = (params.method || 'get').toUpperCase();
+	// set `method` request param
+	params.method = ( params.method || 'get' ).toUpperCase();
 
-  // `query` is optional
-  if ('function' === typeof query) {
-    fn = query;
-    query = {};
-  }
+	// `query` is optional
+	if ( 'function' === typeof query ) {
+		fn = query;
+		query = {};
+	}
 
-  // `body` is optional
-  if ('function' === typeof body) {
-    fn = body;
-    body = null;
-  }
+	// `body` is optional
+	if ( 'function' === typeof body ) {
+		fn = body;
+		body = null;
+	}
 
-  // query could be `null`
-  query = query || {};
+	// query could be `null`
+	query = query || {};
 
-  // Handle special query parameters
-  // - `apiVersion`
-  if (query.apiVersion) {
-    params.apiVersion = query.apiVersion;
-    debug('apiVersion: %o', params.apiVersion);
-    delete query.apiVersion;
-  } else {
-    params.apiVersion = this.apiVersion;
-  }
+	// Handle special query parameters
+	// - `apiVersion`
+	if ( query.apiVersion ) {
+		params.apiVersion = query.apiVersion;
+		debug( 'apiVersion: %o', params.apiVersion );
+		delete query.apiVersion;
+	} else {
+		params.apiVersion = this.apiVersion;
+	}
 
-  // - `proxyOrigin`
-  if (query.proxyOrigin) {
-    params.proxyOrigin = query.proxyOrigin;
-    debug('proxyOrigin: %o', params.proxyOrigin);
-    delete query.proxyOrigin;
-  }
+	// - `proxyOrigin`
+	if ( query.proxyOrigin ) {
+		params.proxyOrigin = query.proxyOrigin;
+		debug( 'proxyOrigin: %o', params.proxyOrigin );
+		delete query.proxyOrigin;
+	}
 
-  // Stringify query object before to send
-  query = qs.stringify(query, { arrayFormat: 'brackets' });
+	// Stringify query object before to send
+	query = qs.stringify( query, {
+		arrayFormat: 'brackets'
+	} );
 
-  // pass `query` and/or `body` to request params
-  params.query = query;
+	// pass `query` and/or `body` to request params
+	params.query = query;
 
-  if (body) {
-    params.body = body;
-  }
-  debug('params: %o', params);
+	if ( body ) {
+		params.body = body;
+	}
+	debug( 'params: %o', params );
 
-  // if callback is provided, behave traditionally
-  if ('function' === typeof fn) {
-    // request method
-    return this.request(params, function(err, res) {
-      debug_res(res);
-      fn(err, res);
-    });
-  }
+	// if callback is provided, behave traditionally
+	if ( 'function' === typeof fn ) {
+		// request method
+		return this.request( params, function( err, res ) {
+			debug_res( res );
+			fn( err, res );
+		} );
+	}
 
-  // but if not, return a Promise
-  return new Promise((resolve, reject) => {
-    this.request(params, (err, res) => {
-      debug_res(res);
-      err ? reject(err) : resolve(res);
-    });
-  } );
+	// but if not, return a Promise
+	return new Promise( ( resolve, reject ) => {
+		this.request( params, ( err, res ) => {
+			debug_res( res );
+			err ? reject( err ) : resolve( res );
+		} );
+	} );
 };


### PR DESCRIPTION
These files define a coding standard roughly equivalent to one used
internally at Automattic, Inc. It adds additional space that wasn't
previously part of the format, meaning that the source files grow in
byte-size, but due to the proliferation and ease of code-compilers such
as `Babel` or `webpack`, these and other examples of "wasted bytes" can
be eliminated automatically.

In order to take advantage of these, you will need to have `esformatter`
and `eslint` installed, as well as the plugins.

```bash
npm install -g eslint esformatter
esformatter-{quotes,semicolons,braces,dot-notation,special-bangs,jsx-ignore}

esformatter -i "$FILE_PATH" -c "$PROJECT_ROOT/.esformatter"

eslint "$FILE_PATH" -c "$PROJECT_ROOT/.eslintrc"
```

Not that if you are inside the project directory, both of these tools
_should_ perform a lookup for the config file traveling back up the
tree, meaning that you should be able to exclude the `-c config_path`
parameter from the invocation.

cc: @retrofox as promised here is an update bringing in coding style. I will reformat the files in another commit, but this is the definition-in-a-config-file. Please let me know if you don't like the way it's setup.