### PR TITLE
Removes the Promise wrapper

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,32 +141,6 @@ WPCOM.prototype.sendRequest = function (params, query, body, fn) {
   return sendRequest.call(this, params, query, body, fn)
 };
 
-/**
- * Wraps a library callback into a Promise
- *
- * Remember to bind the method to its parent
- * context - extracting it out otherwise removes it.
- *
- * E.g.
- * wpcom.Promise( comment.del.bind( comment ) );
- *
- * The promise rejects if the normal error return from
- * an API call is not empty. It resolves otherwise.
- *
- * @param {function} callback wpcom.js method to call
- * @param params variable list of parameters to send to callback
- * @returns {Promise}
- */
-WPCOM.prototype.Promise = ( callback, ...params ) => {
-  return new Promise( ( resolve, reject ) => {
-    // The functions here take a variable number of arguments,
-    // so pass in as many as we can but keep the callback last.
-    callback.apply( callback, [...params, ( error, data ) => {
-      error ? reject( error ) : resolve( data );
-    } ] );
-  } );
-};
-
 if ( ! Promise.prototype.timeout ) {
 	/**
      * Returns a new promise with a deadline

--- a/test/test.wpcom.promises.js
+++ b/test/test.wpcom.promises.js
@@ -26,64 +26,19 @@ function timedCallback( delay, caller = trueCallback ) {
 describe('wpcom', function(){
 	var wpcom = util.wpcom_public();
 
-	describe('wpcom.Promise', function(){
-		it('should resolve when true', done => {
-			wpcom.Promise( trueCallback )
-				.then( trueAssertion( done ) )
-				.catch( falseAssertion( done ) );
-		});
-
-		it('should reject when false', done => {
-			wpcom.Promise( falseCallback )
-				.then( falseAssertion( done ) )
-				.catch( trueAssertion( done ) );
-		});
-
+	describe.only('wpcom.promises', function(){
 		it('should fail when slower than timeout', done => {
-			wpcom.Promise( timedCallback( 1000 ) )
+			wpcom.site(util.site()).postsList()
 				.timeout( 10 )
 				.then( falseAssertion( done ) )
 				.catch( trueAssertion( done ) );
 		});
 
 		it('should still catch() with timeout()', done => {
-			wpcom.Promise( timedCallback( 10, falseCallback ) )
-				.timeout( 1000 )
+			wpcom.site(util.site()).post(-5).get()
+				.timeout( 10000 )
 				.then( falseAssertion( done ) )
 				.catch( trueAssertion( done ) );
-		});
-
-		it('should handle functions with no params', done => {
-			let test = callback => callback( null, 1337 );
-
-			wpcom.Promise( test )
-				.then( data => {
-					assert.equal( data, 1337 );
-					done();
-				})
-				.catch( falseAssertion(done) );
-		});
-
-		it('should handle functions with one param', done => {
-			let test = ( a, callback ) => callback( null, a );
-
-			wpcom.Promise( test, 'spline' )
-				.then( data => {
-					assert.equal( data, 'spline' );
-					done();
-				})
-				.catch( falseAssertion(done) );
-		});
-
-		it('should handle functions with 3+ params', done => {
-			let test = (a, b, c, callback) => { callback( null, a + b + c ); };
-
-			wpcom.Promise( test, 1, 2, 3 )
-				.then( data => {
-					assert.equal( data, 6 );
-					done();
-				})
-				.catch( falseAssertion( done ) );
 		});
 	});
 


### PR DESCRIPTION
This isn't needed since promises are built-in by default now. It was put
in place as a hold-off until a final solution could be found, and the
default promises are working great.