### PR TITLE
Fix typo in Media#addUrls

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -167,7 +167,7 @@ Media.prototype.addUrls = function (query, media, fn) {
           body.attrs[i][k] = m[k];
         }
       }
-      url = m[k];
+      url = m.url;
     }
 
     // push url into [media_url]

--- a/test/fixture.json
+++ b/test/fixture.json
@@ -38,9 +38,9 @@
       "http://s.w.org/about/images/logos/wordpress-logo-notext-rgb.png",
       "http://s.w.org/about/images/logos/wordpress-logo-simplified-rgb.png",
       {
+        "url": "http://s.w.org/about/images/logos/wordpress-logo-notext-rgb.png",
         "title": "Testing Media URL",
-        "description": "Testing media file added from a URL",
-        "url": "http://s.w.org/about/images/logos/wordpress-logo-notext-rgb.png"
+        "description": "Testing media file added from a URL"
       }
     ]
   }


### PR DESCRIPTION
When giving an object (or a list containing an object) to `Media#addUrls`, the url may not be retrieved properly if the `url` key is not the last entry in the object.
This was not detected earlier probably because we usually give url strings to this function, but giving an object is useful to define other attributes (such as the `parent_id`/`post_ID`) for this media.

Related issue https://github.com/Automattic/wpcom.js/issues/119