### PR TITLE
Formalize the coding style already in use

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,36 @@
+{
+  "parser": "babel-eslint",
+  "env": {
+    "es6": true,
+    "browser": true,
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "rules": {
+    "array-bracket-spacing": [ 2, "always" ],
+    "comma-spacing": [ 2, { "before": false, "after": true } ],
+    "eqeqeq": [ 2 ],
+    "indent": [ 2, 2, { "SwitchCase": 1 } ],
+    "linebreak-style": [ 2, "unix" ],
+    "no-lonely-if": [ 2 ],
+    "no-loop-func": [ 2 ],
+    "no-multi-spaces": [ 2 ],
+    "no-nested-ternary": [ 2 ],
+    "no-redeclare": [ 2, { "builtinGlobals": true } ],
+    "no-return-assign": [ 2, "always" ],
+    "no-spaced-func": [ 2 ],
+    "no-trailing-spaces": [ 2 ],
+    "no-unneeded-ternary": [ 2 ],
+    "no-use-before-define": [ 2 ],
+    "no-useless-call": [ 2 ],
+    "no-useless-concat": [ 2 ],
+    "object-curly-spacing": [ 2, "always" ],
+    "quotes": [ 2, "single" ],
+    "radix": [ 2 ],
+    "semi": [ 2, "always" ],
+    "space-before-blocks": [ 2, "always" ],
+    "space-before-function-paren": [ 2, { "anonymous": "always", "named": "never" } ],
+    "vars-on-top": [ 1 ],
+    "wrap-iife": [ 2, "inside" ]
+  }
+}

--- a/index.js
+++ b/index.js
@@ -132,16 +132,16 @@ WPCOM.prototype.freshlyPressed = function (query, fn) {
 
 WPCOM.prototype.sendRequest = function (params, query, body, fn) {
   var msg = 'WARN! Don use `sendRequest() anymore. Use `this.req` method.';
-  if (console && console.warn) {
-    console.warn(msg);
+  if (console && console.warn) { //eslint-disable-line no-console
+    console.warn(msg); //eslint-disable-line no-console
   } else {
-    console.log(msg);
+    console.log(msg); //eslint-disable-line no-console
   }
 
-  return sendRequest.call(this, params, query, body, fn)
+  return sendRequest.call(this, params, query, body, fn);
 };
 
-if ( ! Promise.prototype.timeout ) {
+if (!Promise.prototype.timeout) {
 	/**
      * Returns a new promise with a deadline
      *
@@ -152,21 +152,21 @@ if ( ! Promise.prototype.timeout ) {
      * @param {number} delay how many ms to wait
      * @returns {Promise}
      */
-  Promise.prototype.timeout = function( delay = DEFAULT_ASYNC_TIMEOUT ) {
+  Promise.prototype.timeout = function (delay = DEFAULT_ASYNC_TIMEOUT) {
     let cancelTimeout, timer, timeout;
 
-    timeout = new Promise( ( resolve, reject ) => {
-      timer = setTimeout( () => {
-        reject( new Error( 'Action timed out while waiting for response.' ) );
-      }, delay );
-    } );
+    timeout = new Promise((resolve, reject) => {
+      timer = setTimeout(() => {
+        reject(new Error('Action timed out while waiting for response.'));
+      }, delay);
+    });
 
     cancelTimeout = () => {
-      clearTimeout( timer );
+      clearTimeout(timer);
       return this;
     };
 
-    return Promise.race( [ this.then( cancelTimeout ).catch( cancelTimeout ), timeout ] );
+    return Promise.race([ this.then(cancelTimeout).catch(cancelTimeout), timeout ]);
   };
 }
 

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -1,10 +1,3 @@
-
-/**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:batch');
-
 /**
  * Create a `Batch` instance
  *

--- a/lib/category.js
+++ b/lib/category.js
@@ -1,10 +1,3 @@
-
-/**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:category');
-
 /**
  * Category methods
  *

--- a/lib/comment.js
+++ b/lib/comment.js
@@ -4,7 +4,6 @@
  */
 
 var CommentLike = require('./commentlike');
-var debug = require('debug')('wpcom:comment');
 
 /**
  * Comment methods
@@ -67,11 +66,11 @@ Comment.prototype.replies = function (query, fn) {
  */
 
 Comment.prototype.add = function (query, body, fn) {
-  if ( undefined === fn ) {
-    if ( undefined === body ) {
+  if (undefined === fn) {
+    if (undefined === body) {
       body = query;
       query = {};
-    } else if ( 'function' === typeof body ) {
+    } else if ('function' === typeof body) {
       fn = body;
       body = query;
       query = {};
@@ -148,7 +147,7 @@ Comment.prototype['delete'] = function (query, fn) {
  * @api public
  */
 
-Comment.prototype.like = function() {
+Comment.prototype.like = function () {
   return CommentLike(this._cid, this._sid, this.wpcom);
 };
 

--- a/lib/commentlike.js
+++ b/lib/commentlike.js
@@ -1,10 +1,3 @@
-
-/**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:commentlike');
-
 /**
  * CommentLike methods
  *

--- a/lib/follow.js
+++ b/lib/follow.js
@@ -1,12 +1,5 @@
-
 /**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:follow');
-
-/**
- * Follow 
+ * Follow
  *
  * @param {String} site_id - site id
  * @param {WPCOM} wpcom
@@ -27,7 +20,7 @@ function Follow(site_id, wpcom) {
 }
 
 /**
- * Get the follow status for current 
+ * Get the follow status for current
  * user on current blog sites
  *
  * @param {Object} [query]

--- a/lib/like.js
+++ b/lib/like.js
@@ -1,10 +1,3 @@
-
-/**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:like');
-
 /**
  * Like methods
  *

--- a/lib/me.js
+++ b/lib/me.js
@@ -1,10 +1,3 @@
-
-/**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:me');
-
 /**
  * Create a `Me` instance
  *

--- a/lib/media.js
+++ b/lib/media.js
@@ -7,14 +7,6 @@ var fs = require('fs');
 var debug = require('debug')('wpcom:media');
 
 /**
- * Default
- */
-
-var def = {
-  "apiVersion": "1.1"
-};
-
-/**
  * Media methods
  *
  * @param {String} id
@@ -73,11 +65,11 @@ Media.prototype.update = function (query, body, fn) {
  */
 
 Media.prototype.addFiles = function (query, files, fn) {
-  if ( undefined === fn ) {
-    if ( undefined === files ) {
+  if (undefined === fn) {
+    if (undefined === files) {
       files = query;
       query = {};
-    } else if ( 'function' === typeof files ) {
+    } else if ('function' === typeof files) {
       fn = files;
       files = query;
       query = {};
@@ -90,7 +82,7 @@ Media.prototype.addFiles = function (query, files, fn) {
   };
 
   // process formData
-  files = Array.isArray(files) ? files : [files];
+  files = Array.isArray(files) ? files : [ files ];
 
   var i, f, isStream, isFile, k, param;
   for (i = 0; i < files.length; i++) {
@@ -109,7 +101,7 @@ Media.prototype.addFiles = function (query, files, fn) {
         debug('add %o => %o', k, f[k]);
         if ('file' !== k) {
           param = 'attrs[' + i + '][' + k + ']';
-          params.formData.push([param, f[k]]);
+          params.formData.push([ param, f[k] ]);
         }
       }
       // set file path
@@ -117,7 +109,7 @@ Media.prototype.addFiles = function (query, files, fn) {
       f = 'string' === typeof f ? fs.createReadStream(f) : f;
     }
 
-    params.formData.push(['media[]', f]);
+    params.formData.push([ 'media[]', f ]);
   }
 
   return this.wpcom.req.post(params, query, null, fn);
@@ -132,11 +124,11 @@ Media.prototype.addFiles = function (query, files, fn) {
  */
 
 Media.prototype.addUrls = function (query, media, fn) {
-  if ( undefined === fn ) {
-    if ( undefined === media ) {
+  if (undefined === fn) {
+    if (undefined === media) {
       media = query;
       query = {};
-    } else if ( 'function' === typeof media ) {
+    } else if ('function' === typeof media) {
       fn = media;
       media = query;
       query = {};

--- a/lib/post.js
+++ b/lib/post.js
@@ -97,11 +97,11 @@ Post.prototype.getBySlug = function (query, fn) {
  */
 
 Post.prototype.add = function (query, body, fn) {
-  if ( undefined === fn ) {
-    if ( undefined === body ) {
+  if (undefined === fn) {
+    if (undefined === body) {
       body = query;
       query = {};
-    } else if ( 'function' === typeof body ) {
+    } else if ('function' === typeof body) {
       fn = body;
       body = query;
       query = {};
@@ -119,17 +119,17 @@ Post.prototype.add = function (query, body, fn) {
       this._slug = data.slug;
       debug('Set post _slug: %s', this._slug);
 
-      if ( 'function' === typeof fn ) {
+      if ('function' === typeof fn) {
         fn(null, data);
       } else {
-        return Promise.resolve( data );
+        return Promise.resolve(data);
       }
     })
     .catch(err => {
-      if ( 'function' === typeof fn ) {
+      if ('function' === typeof fn) {
         fn(err);
       } else {
-        return Promise.reject( error );
+        return Promise.reject(err);
       }
     });
 };

--- a/lib/reblog.js
+++ b/lib/reblog.js
@@ -1,10 +1,3 @@
-
-/**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:reblog');
-
 /**
  * Reblog methods
  *
@@ -81,8 +74,8 @@ Reblog.prototype.add = function (query, body, fn) {
  */
 
 Reblog.prototype.to = function (dest, note, fn) {
-  if ( undefined === fn ) {
-    if ( undefined === note ) {
+  if (undefined === fn) {
+    if (undefined === note) {
       note = null;
     } else if ('function' === typeof note) {
       fn = note;

--- a/lib/site.js
+++ b/lib/site.js
@@ -107,7 +107,7 @@ for (i = 0; i < resources.length; i++) {
   res = resources[i];
   isarr = Array.isArray(res);
 
-  name =  isarr ? res[0] : res + 'List';
+  name = isarr ? res[0] : res + 'List';
   subpath = isarr ? res[1] : res;
 
   debug('adding method: %o - sub-path: %o - version: %s', ('site.' + name + '()'), subpath);
@@ -266,7 +266,7 @@ Site.prototype.renderShortcode = function (url, query, fn) {
     throw new TypeError('expected a url String');
   }
 
-  if ('function' == typeof query) {
+  if ('function' === typeof query) {
     fn = query;
     query = {};
   }
@@ -295,7 +295,7 @@ Site.prototype.renderEmbed = function (url, query, fn) {
     throw new TypeError('expected an embed String');
   }
 
-  if ('function' == typeof query) {
+  if ('function' === typeof query) {
     fn = query;
     query = {};
   }
@@ -349,7 +349,7 @@ Site.prototype.statsReferrersSpamDelete = function (domain, fn) {
 Site.prototype.statsVideo = function (videoId, query, fn) {
   var path = '/sites/' + this._id + '/stats/video/' + videoId;
 
-  if ('function' == typeof query) {
+  if ('function' === typeof query) {
     fn = query;
     query = {};
   }
@@ -369,7 +369,7 @@ Site.prototype.statsVideo = function (videoId, query, fn) {
 Site.prototype.statsPostViews = function (postId, query, fn) {
   var path = '/sites/' + this._id + '/stats/post/' + postId;
 
-  if ('function' == typeof query) {
+  if ('function' === typeof query) {
     fn = query;
     query = {};
   }

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -1,10 +1,3 @@
-
-/**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:tag');
-
 /**
  * Tag methods
  *

--- a/lib/users.js
+++ b/lib/users.js
@@ -1,10 +1,3 @@
-
-/**
- * Module dependencies.
- */
-
-var debug = require('debug')('wpcom:users');
-
 /**
  * Create a `Users` instance
  *

--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -4,7 +4,6 @@
  */
 
 var sendRequest = require('./send-request');
-var debug = require('debug')('wpcom:request');
 
 /**
  * Expose `Request` module
@@ -12,6 +11,7 @@ var debug = require('debug')('wpcom:request');
 
 
 function Req(wpcom) {
+
   this.wpcom = wpcom;
 }
 
@@ -26,7 +26,7 @@ function Req(wpcom) {
 
 Req.prototype.get = function (params, query, fn) {
   // `query` is optional
-  if ('function' == typeof query) {
+  if ('function' === typeof query) {
     fn = query;
     query = {};
   }
@@ -49,8 +49,8 @@ Req.prototype.put = function (params, query, body, fn) {
   if (undefined === fn) {
     if (undefined === body) {
       body = query;
-      query = {}
-    } else if ( 'function' === typeof body) {
+      query = {};
+    } else if ('function' === typeof body) {
       fn = body;
       body = query;
       query = {};
@@ -76,7 +76,7 @@ Req.prototype.put = function (params, query, body, fn) {
  */
 
 Req.prototype.del = function (params, query, fn) {
-  if ('function' == typeof query) {
+  if ('function' === typeof query) {
     fn = query;
     query = {};
   }

--- a/lib/util/send-request.js
+++ b/lib/util/send-request.js
@@ -72,7 +72,7 @@ module.exports = function (params, query, body, fn) {
   // if callback is provided, behave traditionally
   if ('function' === typeof fn) {
     // request method
-    return this.request(params, function(err, res) {
+    return this.request(params, function (err, res) {
       debug_res(res);
       fn(err, res);
     });
@@ -84,5 +84,5 @@ module.exports = function (params, query, body, fn) {
       debug_res(res);
       err ? reject(err) : resolve(res);
     });
-  } );
+  });
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Automattic, Inc.",
   "contributors": [
     "Damian Suarez <rdsuarez@gmail.com>",
-    "Nathan Rajlich <nathan@automattic.com>"
+    "Nathan Rajlich <nathan@automattic.com>",
+    "Dennis Snell <dennis.snell@automattic.com>"
   ],
   "keywords": [
     "wordpress",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "babel": "^5.8.23",
+    "babel-eslint": "^4.1.3",
     "browserify": "^11.0.1",
     "mocha": "^2.2.5"
   }


### PR DESCRIPTION
I generated this config based on the existing library coding style. It
formalizes patterns in use but doesn't attempt to change them.

In cases where multiple styles were present, the pattern most-used was
selected. Usually there were no close-calls.