### PR TITLE
Remove deprecated `me/connections` endpoint

### DIFF
--- a/docs/me.md
+++ b/docs/me.md
@@ -60,13 +60,3 @@ me.groups(function(err, list){
   // groups list object
 });
 ```
-
-### Me#connections([query, ]fn)
-
-Get a list of the current user's connections to third-party services
-
-```js
-me.connections(function(err, list){
-  // connections list object
-});
-```

--- a/lib/me.js
+++ b/lib/me.js
@@ -61,17 +61,6 @@ Me.prototype.groups = function (query, fn) {
   return this.wpcom.req.get('/me/groups', query, fn);
 };
 
-/**
- * A list of the current user's connections to third-party services
- *
- * @param {Object} [query]
- * @param {Function} fn
- * @api public
- */
-
-Me.prototype.connections = function (query, fn) {
-  return this.wpcom.req.get('/me/connections', query, fn);
-};
 
 /**
  * Expose `Me` module

--- a/test/test.wpcom.me.js
+++ b/test/test.wpcom.me.js
@@ -88,17 +88,4 @@ describe('wpcom.me', function(){
     });
   });
 
-  describe('wpcom.me.connections', function(){
-    it('should require third-party connections', done => {
-      me.connections()
-        .then(data => {
-          assert.equal('object', typeof data.connections);
-          assert.ok(data.connections instanceof Array);
-
-          done();
-        })
-        .catch(done);
-    });
-  });
-
 });


### PR DESCRIPTION
The `me/connections` endpoint has been deprecated and removed from WordPress.com's REST API. It was never a documented endpoint, so its removal does not affect any production clients. 

The endpoints are replaced by equivalent (but still undocumented for now) v1.1 endpoints. Once documented, I believe we can add them to wpcom.js.

Note: I wasn't sure if I should also apply the removal to `/dist` or if there is some automated process that takes care of that for us.

Pinging @aduth for a review.