### PR TITLE
Move babel-runtime to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "babel": "^5.8.23",
+    "babel-runtime": "5.8.12",
     "debug": "^2.2.0",
     "json-loader": "^0.5.4",
     "qs": "^4.0.0",
@@ -31,7 +32,6 @@
     "babel-core": "^5.8.23",
     "babel-eslint": "^4.1.6",
     "babel-loader": "^5.3.2",
-    "babel-runtime": "5.8.12",
     "eslint": "^1.10.1",
     "mocha": "^2.3.4",
     "strip-loader": "^0.1.0",


### PR DESCRIPTION
While working on my wcus talk with the example app [here](https://github.com/timmyc/doggfood), the new promises logic broke my build since `babel-runtime` is not an explicit dependency in this package.  I believe everything is working fine in wp-calypso with the current build because that package is required explicitly by that project.

I was able to fix my example app by adding the dependency too, but we should fix it here as well.

/cc @retrofox 