### PR TITLE
WP-API: Add support for apiNamespace

### DIFF
--- a/lib/util/send-request.js
+++ b/lib/util/send-request.js
@@ -48,6 +48,13 @@ module.exports = function( params, query, body, fn ) {
 		params.apiVersion = this.apiVersion;
 	}
 
+	// - `apiNamespace`
+	if ( query.apiNamespace ) {
+		params.apiNamespace = query.apiNamespace;
+		debug( 'apiNamespace: %o', params.apiNamespace );
+		delete query.apiNamespace;
+	}
+
 	// - `proxyOrigin`
 	if ( query.proxyOrigin ) {
 		params.proxyOrigin = query.proxyOrigin;


### PR DESCRIPTION
Adding in some more logic to support the upcoming adoption of WP-API on WordPress.com.  In lieu of keying off of `apiVersion` we are opting to add in a new "special" param for `apiNamespace`.  The WP-API uses namespaces to group logic - for example the default namespace is `wp/2` - and probably down the road as we migrate existing wpcom endpoints to WP-API we will use `wpcom/2.0`.

Our initial hope was to treat any `apiVersion` >= 2.0 as a WP-API request, but as we vetted this out further, we realized that approach might cause issues in the future.  Case in point - there is an `oembed/1.0` namespace and version combo right now that would not work with using apiVersion >= 2.0 logic.

With this logic in place we can sniff for `apiNamespace` in the rest-proxy and `wpcom-xhr-request` and adjust the base paths as necessary.

/cc @retrofox 