### PR TITLE
Release 4.8.4

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,9 @@
 
+4.8.3 / 2015-2-18
+==================
+
+* adds support for special `apiNamespace` param to integrate core WP-API
+
 4.8.3 / 2015-12-10
 ==================
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wpcom",
   "description": "Official JavaScript library for the WordPress.com REST API",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "main": "dist/index.js",
   "author": "Automattic, Inc.",
   "contributors": [


### PR DESCRIPTION
Version bump to get `apiNamespace` available for use.

/cc @retrofox 