### PR TITLE
Tests: Fix issues when running with single-site token

### DIFF
--- a/test/test.wpcom.me.js
+++ b/test/test.wpcom.me.js
@@ -11,125 +11,130 @@ describe( 'wpcom.me', function() {
 	// Global instances
 	var wpcom = util.wpcom();
 	var me = wpcom.me();
+	var runTests = util.hasGlobalToken;
 
-	describe( 'wpcom.me.billingHistory', function() {
-		it( 'should require billing history', function( done ) {
-			me.billingHistory( function( err, data ) {
-				if ( err ) throw err;
+	if ( runTests ) {
+		describe( 'wpcom.me.billingHistory', function() {
+			it( 'should require billing history', function( done ) {
+				me.billingHistory( function( err, data ) {
+					if ( err ) throw err;
 
-				assert.ok( data );
-				assert.equal( 'object', typeof data.billing_history );
-				assert.ok( data.billing_history instanceof Array );
+					assert.ok( data );
+					assert.equal( 'object', typeof data.billing_history );
+					assert.ok( data.billing_history instanceof Array );
 
-				assert.equal( 'object', typeof data.upcoming_charges );
-				assert.ok( data.upcoming_charges instanceof Array );
+					assert.equal( 'object', typeof data.upcoming_charges );
+					assert.ok( data.upcoming_charges instanceof Array );
 
-				done();
+					done();
+				} );
 			} );
 		} );
-	} );
 
-	describe( 'wpcom.me.get', function() {
-		it( 'should require user information object', done => {
-			me.get()
-				.then( data => {
-					// testing object
-					assert.ok( data );
-					assert.equal( 'object', typeof data );
+		describe( 'wpcom.me.get', function() {
+			it( 'should require user information object', done => {
+				me.get()
+					.then( data => {
+						// testing object
+						assert.ok( data );
+						assert.equal( 'object', typeof data );
 
-					// testing user data
-					assert.equal( 'number', typeof data.ID );
+						// testing user data
+						assert.equal( 'number', typeof data.ID );
 
-					done();
-				} )
-				.catch( done );
+						done();
+					} )
+					.catch( done );
+			} );
+
+			it( 'should require user passing query parameter', done => {
+				me.get( { context: 'info' } )
+					.then( data => {
+						// testing object
+						assert.ok( me );
+						assert.equal( 'object', typeof data );
+
+						// testing user data
+						assert.equal( 'number', typeof data.ID );
+
+						done();
+					} )
+					.catch( done );
+			} );
 		} );
 
-		it( 'should require user passing query parameter', done => {
-			me.get( { context: 'info' } )
-				.then( data => {
-					// testing object
-					assert.ok( me );
-					assert.equal( 'object', typeof data );
+		describe( 'wpcom.me.groups', function() {
+			it( 'should require groups', done => {
+				me.groups()
+					.then( data => {
+						assert.equal( 'object', typeof data.groups );
+						assert.ok( data.groups instanceof Array );
 
-					// testing user data
-					assert.equal( 'number', typeof data.ID );
-
-					done();
-				} )
-				.catch( done );
+						done();
+					} )
+					.catch( done );
+			} );
 		} );
-	} );
 
-	describe( 'wpcom.me.groups', function() {
-		it( 'should require groups', done => {
-			me.groups()
-				.then( data => {
-					assert.equal( 'object', typeof data.groups );
-					assert.ok( data.groups instanceof Array );
-
-					done();
-				} )
-				.catch( done );
+		describe( 'wpcom.me.keyringConnections', function() {
+			it( 'should get current user\' keyring connections', done => {
+				me.keyringConnections()
+					.then( data => {
+						assert.ok( data );
+						assert.ok( data.connections instanceof Array );
+						done();
+					} )
+					.catch( done );
+			} );
 		} );
-	} );
 
-	describe( 'wpcom.me.keyringConnections', function() {
-		it( 'should get current user\' keyring connections', done => {
-			me.keyringConnections()
-				.then( data => {
-					assert.ok( data );
-					assert.ok( data.connections instanceof Array );
-					done();
-				} )
-				.catch( done );
+		describe( 'wpcom.me.likes', function() {
+			it( 'should require user likes', done => {
+				me.likes()
+					.then( data => {
+						assert.equal( 'number', typeof data.found );
+						assert.equal( 'object', typeof data.likes );
+						assert.ok( data.likes instanceof Array );
+
+						done();
+					} )
+					.catch( done );
+			} );
 		} );
-	} );
 
-	describe( 'wpcom.me.likes', function() {
-		it( 'should require user likes', done => {
-			me.likes()
-				.then( data => {
-					assert.equal( 'number', typeof data.found );
-					assert.equal( 'object', typeof data.likes );
-					assert.ok( data.likes instanceof Array );
-
-					done();
-				} )
-				.catch( done );
+		describe( 'wpcom.me.postsList', function() {
+			it( 'should get posts list that current user belongs to', function( done ) {
+				me.postsList()
+					.then( data => {
+						assert.equal( 'number', typeof data.found );
+						assert.equal( 'object', typeof data.meta );
+						assert.ok( data.posts instanceof Array );
+						done();
+					} )
+					.catch( done );
+			} );
 		} );
-	} );
 
-	describe( 'wpcom.me.postsList', function() {
-		it( 'should get posts list that current user belongs to', function( done ) {
-			me.postsList()
-				.then( data => {
-					assert.equal( 'number', typeof data.found );
-					assert.equal( 'object', typeof data.meta );
-					assert.ok( data.posts instanceof Array );
-					done();
-				} )
-				.catch( done );
+		describe( 'wpcom.me.publicizeConnections', function() {
+			it( 'should get current user\' publicize connections', done => {
+				me.publicizeConnections()
+					.then( data => {
+						assert.ok( data );
+						assert.ok( data.connections instanceof Array );
+						done();
+					} )
+					.catch( done );
+			} );
 		} );
-	} );
 
-	describe( 'wpcom.me.publicizeConnections', function() {
-		it( 'should get current user\' publicize connections', done => {
-			me.publicizeConnections()
-				.then( data => {
-					assert.ok( data );
-					assert.ok( data.connections instanceof Array );
-					done();
-				} )
-				.catch( done );
+		describe( 'wpcom.me.sites', function() {
+			it( 'should require user sites object', done => {
+				me.sites()
+					.then( () => done() )
+					.catch( done );
+			} );
 		} );
-	} );
-
-	describe( 'wpcom.me.sites', function() {
-		it( 'should require user sites object', done => {
-			me.sites()
-				.then( () => done() )
-				.catch( done );
-		} );
-	} );
+	} else {
+		console.log( 'No Global Token: Skipping wpcom.me tests' );
+	}
 } );

--- a/test/test.wpcom.me.publicize-connection.js
+++ b/test/test.wpcom.me.publicize-connection.js
@@ -12,35 +12,40 @@ describe( 'wpcom.me.publicizeConnection', function() {
 	// Global instances
 	var wpcom = util.wpcom();
 	var me = wpcom.me();
+	var runTests = util.hasGlobalToken;
 
-	describe( 'wpcom.me.publicizeConnection.get', function() {
-		it( 'should get current user\' publicize connections', function( done ) {
-			me.publicizeConnections( function( err, data ) {
-				if ( err ) throw err;
+	if ( runTests ) {
+		describe( 'wpcom.me.publicizeConnection.get', function() {
+			it( 'should get current user\' publicize connections', function( done ) {
+				me.publicizeConnections( function( err, data ) {
+					if ( err ) throw err;
 
-				assert.ok( data );
-				assert.ok( data.connections );
+					assert.ok( data );
+					assert.ok( data.connections );
 
-				let connectionId = data.publicize_connections && data.publicize_connections[0]
-					? data.publicize_connections[0].ID
-					: null;
+					let connectionId = data.publicize_connections && data.publicize_connections[0]
+						? data.publicize_connections[0].ID
+						: null;
 
-				if ( connectionId ) {
-					describe( 'wpcom.me.publicizeConnection.get', function() {
-						it( 'should get user publicize connection through of connection id',
-						function( done2 ) {
-							me.publicizeConnection( connectionId ).get( function( err2, data2 ) {
-								if ( err2 ) throw err2;
+					if ( connectionId ) {
+						describe( 'wpcom.me.publicizeConnection.get', function() {
+							it( 'should get user publicize connection through of connection id',
+							function( done2 ) {
+								me.publicizeConnection( connectionId ).get( function( err2, data2 ) {
+									if ( err2 ) throw err2;
 
-								assert.ok( data2 );
-								assert.equal( connectionId, data2.ID );
-								done2();
+									assert.ok( data2 );
+									assert.equal( connectionId, data2.ID );
+									done2();
+								} );
 							} );
 						} );
-					} );
-				}
-				done();
+					}
+					done();
+				} );
 			} );
 		} );
-	} );
+	} else {
+		console.log( 'No Global Token: Skipping wpcom.me.publicize-connection tests' );
+	}
 } );

--- a/test/util.js
+++ b/test/util.js
@@ -53,11 +53,12 @@ if ( isClientSide ) {
 
 module.exports = {
 	wpcom: wpcom,
+	hasGlobalToken: process.env.GLOBAL || config.isGlobalToken,
 	wpcomPublic: function() {
 		return wpcomFactory();
 	},
 	site: function() {
-		return fixture.site || process.env.SITE;
+		return process.env.SITE || config.site || fixture.site;
 	},
 	wordAds: function() {
 		return config.wordads;


### PR DESCRIPTION
Currently when attempting to run the test suite with a single-site token, any global ( i.e. `/me` ) tests fail.  This update adds a switch to toggle running of these tests via an ENV variable `GLOBAL`.

Additionally, some logic in the test/util file was always using the fixture site in lieu of what was set in the config or passed in via an ENV argument.

/cc @retrofox 

Also it is unclear to me how to run the client-side tests - that can be seen here http://wpcomjs.com/tests/