### PR TITLE
Update test documentation and fix test suite for non-Automattic tokens.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,11 @@ The `token` and `site` vars must be given to testing scripts either using
 config.json file into `test/` folder like bellow:
 
 ```json
-{
-	"site": "<site-id>",
-	"token": "<token>"
+{ "development": {
+	"site": "site.ID or domain",
+	"token": "Your Token",
+	"skipRestrictedEndpoints": true, // some endpoints require special permissions to access
+	}
 }
 ```
 
@@ -117,6 +119,37 @@ Also tests can be filtered using `make test <filter>`:
 ```cli
 $ make test wpcom.site.post
 ```
+
+## Browser Tests
+
+To run the test suite in a browser, you will need to have `serve` installed globally:
+
+```cli
+$ npm install -g serve
+```
+
+Additionally you will need to add some oauth details to your `test\config.json`:
+
+```json
+{ "development": {
+	"site": "site.ID or domain",
+	"token": "Your Token",
+	"skipRestrictedEndpoints": true,
+	"oauth": {
+		"client_id": "client ID from oauth app used to generate your token",
+		"options": {
+			"scope": "global"
+		}
+	}
+}
+```
+You can then run the local test app by executing:
+
+```cli
+$ make run-test-app
+```
+
+And then open up your browser to `http://calypso.localhost:3001`.
 
 ## License
 

--- a/test/test.wpcom.me.js
+++ b/test/test.wpcom.me.js
@@ -62,16 +62,21 @@ describe( 'wpcom.me', function() {
 	} );
 
 	describe( 'wpcom.me.groups', function() {
-		it( 'should require groups', done => {
-			me.groups()
-				.then( data => {
-					assert.equal( 'object', typeof data.groups );
-					assert.ok( data.groups instanceof Array );
+		// me.groups is a restricted endpoint for Automattic Employees
+		if ( util.testRestrictedEndpoints() ) {
+			it( 'should require groups', done => {
+				me.groups()
+					.then( data => {
+						assert.equal( 'object', typeof data.groups );
+						assert.ok( data.groups instanceof Array );
 
-					done();
-				} )
-				.catch( done );
-		} );
+						done();
+					} )
+					.catch( done );
+			} );
+		} else {
+			console.log( 'Skipping restricted endpoint test' );
+		}
 	} );
 
 	describe( 'wpcom.me.keyringConnections', function() {
@@ -105,7 +110,6 @@ describe( 'wpcom.me', function() {
 			me.postsList()
 				.then( data => {
 					assert.equal( 'number', typeof data.found );
-					assert.equal( 'object', typeof data.meta );
 					assert.ok( data.posts instanceof Array );
 					done();
 				} )

--- a/test/test.wpcom.site.js
+++ b/test/test.wpcom.site.js
@@ -94,8 +94,9 @@ describe( 'wpcom.site', function() {
 				site.postCounts( 'post', function( err, data ) {
 					if ( err ) throw err;
 
-					assert.ok( 1 <= data.counts.all.draft );
-					assert.ok( 1 <= data.counts.mine.draft );
+					assert.ok( data.counts instanceof Object );
+					assert.ok( data.counts.all instanceof Object );
+					assert.ok( data.counts.mine instanceof Object );
 					done();
 				} );
 			} );
@@ -104,8 +105,9 @@ describe( 'wpcom.site', function() {
 				site.postCounts( 'page', function( err, data ) {
 					if ( err ) throw err;
 
-					assert.ok( 1 <= data.counts.all.draft );
-					assert.ok( 1 <= data.counts.mine.draft );
+					assert.ok( data.counts instanceof Object );
+					assert.ok( data.counts.all instanceof Object );
+					assert.ok( data.counts.mine instanceof Object );
 					done();
 				} );
 			} );

--- a/test/util.js
+++ b/test/util.js
@@ -57,7 +57,16 @@ module.exports = {
 		return wpcomFactory();
 	},
 	site: function() {
-		return fixture.site || process.env.SITE;
+		// check for existence of config in this env, and site if available
+		var site = config && config.site ? config.site : null;
+
+		return site || fixture.site || process.env.SITE;
+	},
+	testRestrictedEndpoints: function() {
+		if ( config && config.skipRestrictedEndpoints ) {
+			return false;
+		}
+		return true;
 	},
 	wordAds: function() {
 		return config.wordads;


### PR DESCRIPTION
This branch fixes some failing tests that are encountered when running the test suite under the following conditions:

- Using a token generated from a non-automattic wpcom account
- Testing against a brand new site with no posts or drafts

A new testing config flag `skipRestrictedEndpoints` can be configured to skip over any test cases that hit protected endpoints.  `site.postCounts` tests have been updated to only test for the presence of `all` and `mine` objects in the response, not specific values - sidenote there is a proposed API patch in the works for including all post status here, not just ones with > 0 values.

Additionally the README was updated to better document how to run the client-side test suite.

Thanks for the help with the documentation @retrofox 

#### To Test
Run the test suite and ensure everything passes