### PR TITLE
Add/timezones endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,9 +123,21 @@ WPCOM.prototype.freshlyPressed = function( query, fn ) {
 };
 
 /**
-* Expose send-request
-* @TODO: use `this.req` instead of this method
-*/
+ * Timezones list
+ *
+ * @param {Object} [query] - optional query object
+ * @param {Function} fn - callback function
+ * @return {Function} request handler
+ * @api public
+ */
+WPCOM.prototype.timezones = function( query, fn ) {
+	return this.req.get( '/timezones', query, fn );
+};
+
+/**
+ * Expose send-request
+ * @TODO: use `this.req` instead of this method
+ */
 
 WPCOM.prototype.sendRequest = function( params, query, body, fn ) {
 	var msg = 'WARN! Don use `sendRequest() anymore. Use `this.req` method.';

--- a/test/test.wpcom.timezones.js
+++ b/test/test.wpcom.timezones.js
@@ -1,0 +1,33 @@
+/**
+ * Module dependencies
+ */
+var util = require( './util' );
+var assert = require( 'assert' );
+
+/**
+ * wpcom.timezones
+ */
+describe( 'wpcom.timezones', function() {
+	it( 'should get timezones list', function( done ) {
+		var wpcom = util.wpcom();
+
+		wpcom.timezones()
+			.then( data => {
+				assert.ok( data );
+
+				assert.ok( typeof( data.found ) === 'number' );
+
+				assert.ok( data.timezones );
+				assert.ok( data.timezones instanceof Array );
+
+				assert.ok( data.timezones_by_continent );
+				assert.ok( data.timezones_by_continent instanceof Object );
+
+				assert.ok( data.manual_utc_offsets );
+				assert.ok( data.manual_utc_offsets instanceof Array );
+
+				done();
+			} )
+			.catch( done );
+	} );
+} );

--- a/test/util.js
+++ b/test/util.js
@@ -27,7 +27,7 @@ const env = isClientSide && (
 		? 'production'
 		: 'development';
 
-console.log( `environmen: %o`, env );
+console.log( 'environment: %s', env );
 
 const config = configFactory[ env ];
 


### PR DESCRIPTION
Add `.timezones()` method to get response data object hitting to `/timezones` endpoint