### PR TITLE
Add `site.domain`

### DIFF
--- a/lib/runtime/site.get.json
+++ b/lib/runtime/site.get.json
@@ -3,6 +3,7 @@
 	{ "name": "commentsList", "subpath": "comments" },
 	{ "name": "embedsList", "subpath": "embeds" },
 	{ "name": "embedsList", "subpath": "embeds" },
+	{ "name": "domainsList", "subpath": "domains" },
 	{ "name": "followsList", "subpath": "follows" },
 	{ "name": "mediaList", "subpath":  "media" },
 	{ "name": "pageTemplates", "subpath": "page-templates" },

--- a/lib/site.domain.js
+++ b/lib/site.domain.js
@@ -1,0 +1,76 @@
+
+/**
+ * Module variables
+ */
+const root = '/sites';
+
+class SiteDomain {
+	/**
+	 * `SiteDomain` constructor.
+	 *
+	 * @param {Number|String} id - site identifier
+	 * @param {WPCOM} wpcom - wpcom instance
+	 * @return {Undefined} undefined
+	 */
+	constructor( id, wpcom ) {
+		if ( ! ( this instanceof SiteDomain ) ) {
+			return new SiteDomain( id, wpcom );
+		}
+		this._sid = id;
+		this.path = `${root}/${this._sid}/domains`;
+		this.wpcom = wpcom;
+	}
+
+	/**
+	 * Get the primary domain for a site
+	 *
+	 * @param {Object} [query] - query object parameter
+	 * @param {Function} [fn] - callback function
+	 * @return {Function} request handler
+	 */
+	getPrimary( query, fn ) {
+		return this.wpcom.req.get( `${this.path}/primary`, query, fn );
+	}
+
+	/**
+	 * Set the primary domain for a site
+	 *
+	 * @param {String} domain - domain to set
+	 * @param {Function} [fn] - callback function
+	 * @return {Function} request handler
+	 */
+	setPrimary( domain, fn ) {
+		return this.wpcom.req.put( `${this.path}/primary`, {}, { domain }, fn );
+	}
+
+	/**
+	 * Get the redirect status for a site
+	 *
+	 * @param {Object} [query] - query object parameter
+	 * @param {Function} [fn] - callback function
+	 * @return {Function} request handler
+	 */
+	getRedirect( query, fn ) {
+		return this.wpcom.req.get( `${this.path}/redirect`, query, fn );
+	}
+
+	/**
+	 * Set the redirect location for a site
+	 *
+	 * @param {String|Object} location - location to set
+	 * @param {Function} [fn] - callback function
+	 * @return {Function} request handler
+	 */
+	setRedirect( location, fn ) {
+		if ( typeof location === 'string' ) {
+			location = { location };
+		}
+
+		return this.wpcom.req.put( `${this.path}/redirect`, {}, location, fn );
+	}
+}
+
+/**
+ * Expose `SiteDomain` module
+ */
+export default SiteDomain;

--- a/lib/site.js
+++ b/lib/site.js
@@ -9,6 +9,7 @@ var Comment = require( './site.comment' );
 var SiteWordAds = require( './site.wordads' );
 var Follow = require( './site.follow' );
 var addRuntimeMethods = require( './util/runtime-builder' );
+var SiteDomain = require( './site.domain' );
 var SiteSettings = require( './site.settings' );
 var siteGetMethods = require( './runtime/site.get' );
 var debug = require( 'debug' )( 'wpcom:site' );
@@ -174,6 +175,15 @@ Site.prototype.tag = function( slug ) {
  */
 Site.prototype.settings = function() {
 	return new SiteSettings( this._id, this.wpcom );
+};
+
+/**
+ * Create a `SiteDomain` instance
+ *
+ * @return {SiteDomain} SiteDomain instance
+ */
+Site.prototype.domain = function() {
+	return new SiteDomain( this._id, this.wpcom );
 };
 
 /**

--- a/test/test.wpcom.site.domain.js
+++ b/test/test.wpcom.site.domain.js
@@ -1,0 +1,26 @@
+/**
+ * Module dependencies
+ */
+var util = require( './util' );
+var assert = require( 'assert' );
+
+/**
+ * site.domain
+ */
+describe( 'wpcom.site.domain', function() {
+	// Global instances
+	var wpcom = util.wpcom();
+	var site = wpcom.site( util.site() );
+	var domain = site.domain();
+
+	describe( 'wpcom.site.domain', function() {
+		it( 'should get primary domain of the site', done => {
+			domain.getPrimary()
+				.then( data => {
+					assert.ok( data );
+					done();
+				} )
+				.catch( done );
+		} );
+	} );
+} );

--- a/test/test.wpcom.site.js
+++ b/test/test.wpcom.site.js
@@ -41,6 +41,20 @@ describe( 'wpcom.site', function() {
 	} );
 
 	describe( 'wpcom.site.lists', function() {
+		describe( 'wpcom.site.domainsList', function() {
+			it( 'should request domains list', done => {
+				site.domainsList()
+					.then( list => {
+						// list object data testing
+						assert.equal( 'object', typeof list );
+						assert.equal( 'object', typeof list.domains );
+						assert.ok( list.domains instanceof Array );
+						done();
+					} )
+					.catch( done );
+			} );
+		} );
+
 		describe( 'wpcom.site.postsList', function() {
 			it( 'should request posts list', done => {
 				site.postsList()


### PR DESCRIPTION
Add site domain methods

```es6
import wpcomFactory from 'wpcom';

const wpcom = wpcomFactory();
const site = wpcom.site( '<your-testing-blog>' );

// get domains list for the site
site.domainsList().then( list => {
  console.log( 'domains list %o', list );
} );

// create domains handler
const domain = site.domain();

// get primary domain for the website
domain.getPrimary().then( data => {
  // data response
} );
```

## Added methods

### Site#domainsList()

### SiteDomain#getPrimary()

### SiteDomain#setPrimary()

### SiteDomain#getRedirect()

### SiteDomain#setRedirect()