### PR TITLE
Add back post.del() and some test updates.

### DIFF
--- a/dist/lib/site.post.js
+++ b/dist/lib/site.post.js
@@ -224,6 +224,19 @@ var SitePost = (function () {
 		}
 
 		/**
+   * Del post, alias of Delete
+   *
+   * @param {Object} [query] - query object parameter
+   * @param {Function} fn - callback function
+   * @return {Promise} Promise
+   */
+	}, {
+		key: 'del',
+		value: function del(query, fn) {
+			return this['delete'](query, fn);
+		}
+
+		/**
    * Restore post
    *
    * @param {Object} [query] - query object parameter

--- a/lib/site.post.js
+++ b/lib/site.post.js
@@ -169,6 +169,17 @@ class SitePost {
 	}
 
 	/**
+	 * Del post, alias of Delete
+	 *
+	 * @param {Object} [query] - query object parameter
+	 * @param {Function} fn - callback function
+	 * @return {Promise} Promise
+	 */
+	del( query, fn ) {
+		return this.delete( query, fn );
+	}
+
+	/**
 	 * Restore post
 	 *
 	 * @param {Object} [query] - query object parameter

--- a/test/test.wpcom.site.js
+++ b/test/test.wpcom.site.js
@@ -108,8 +108,9 @@ describe( 'wpcom.site', function() {
 				site.postCounts( 'post', function( err, data ) {
 					if ( err ) throw err;
 
-					assert.ok( 1 <= data.counts.all.draft );
-					assert.ok( 1 <= data.counts.mine.draft );
+					assert.ok( data.counts instanceof Object );
+					assert.ok( data.counts.all instanceof Object );
+					assert.ok( data.counts.mine instanceof Object );
 					done();
 				} );
 			} );
@@ -118,8 +119,9 @@ describe( 'wpcom.site', function() {
 				site.postCounts( 'page', function( err, data ) {
 					if ( err ) throw err;
 
-					assert.ok( 1 <= data.counts.all.draft );
-					assert.ok( 1 <= data.counts.mine.draft );
+					assert.ok( data.counts instanceof Object );
+					assert.ok( data.counts.all instanceof Object );
+					assert.ok( data.counts.mine instanceof Object );
 					done();
 				} );
 			} );

--- a/test/test.wpcom.site.post.js
+++ b/test/test.wpcom.site.post.js
@@ -118,6 +118,27 @@ describe( 'wpcom.site.post', function() {
 		} );
 	} );
 
+	describe( 'wpcom.site.post.del', function() {
+		it( 'should delete the post using del()', done => {
+			let test_post;
+			site.addPost( fixture.post )
+				.then( data_post => {
+					test_post = data_post;
+					return data_post;
+				} )
+				.then( ( data_post ) => {
+					return site.post( data_post.ID ).del();
+				} )
+				.then( data => {
+					assert.ok( data );
+					assert.equal( test_post.ID, data.ID );
+
+					done();
+				} )
+				.catch( done );
+		} );
+	} );
+
 	describe( 'wpcom.site.post.restore', function() {
 		it( 'should restore a post from trash', done => {
 			var post = site.post();

--- a/test/util.js
+++ b/test/util.js
@@ -57,7 +57,10 @@ module.exports = {
 		return wpcomFactory();
 	},
 	site: function() {
-		return fixture.site || process.env.SITE;
+		// check for existence of config in this env, and site if available
+		var site = config && config.site ? config.site : null;
+
+		return site || fixture.site || process.env.SITE;
 	},
 	wordAds: function() {
 		return config.wordads;


### PR DESCRIPTION
The `post.del()` method was removed [here](https://github.com/Automattic/wpcom.js/commit/62c8b0350d9c1e1adfcc3ba9ca17273fbdd6da37#diff-e8f27921d011a8bda23fc19c8ef33536) which resulted in some breakage in wp-calypso.  This branch adds the method back in, along with a test for it.

There is also some test suite fixes that I had originally submitted in #157.  Specifically, the change to the test utils will respect a site.ID if set in `lib/test/config.json` or a `SITE` passed in as an ENV variable.  Additionally the `postCounts` tests are fixed up to work on test sites that have no posts.

__To Test__
- `make test site.post.del`
- `make test site.postCounts`