### PR TITLE
Enable support for post types taxonomies endpoint

### DIFF
--- a/dist/lib/site.js
+++ b/dist/lib/site.js
@@ -51,6 +51,10 @@ var _siteTaxonomy = require('./site.taxonomy');
 
 var _siteTaxonomy2 = _interopRequireDefault(_siteTaxonomy);
 
+var _sitePostType = require('./site.post-type');
+
+var _sitePostType2 = _interopRequireDefault(_sitePostType);
+
 var _siteWordads = require('./site.wordads');
 
 var _siteWordads2 = _interopRequireDefault(_siteWordads);
@@ -298,6 +302,18 @@ var Site = (function () {
 		key: 'taxonomy',
 		value: function taxonomy(slug) {
 			return new _siteTaxonomy2['default'](slug, this._id, this.wpcom);
+		}
+
+		/**
+   * Create a `SitePostType` instance
+   *
+   * @param {String} [slug] - post type slug
+   * @return {SitePostType} SitePostType instance
+   */
+	}, {
+		key: 'postType',
+		value: function postType(slug) {
+			return new _sitePostType2['default'](slug, this._id, this.wpcom);
 		}
 
 		/**

--- a/dist/lib/site.post-type.js
+++ b/dist/lib/site.post-type.js
@@ -1,0 +1,63 @@
+var _createClass = require('babel-runtime/helpers/create-class')['default'];
+
+var _classCallCheck = require('babel-runtime/helpers/class-call-check')['default'];
+
+Object.defineProperty(exports, '__esModule', {
+	value: true
+});
+/**
+ * SitePostType class
+ */
+
+var SitePostType = (function () {
+	/**
+  * Create a SitePostType instance
+  *
+  * @param {String} postType - post type
+  * @param {String} siteId - site id
+  * @param {WPCOM} wpcom - wpcom instance
+  * @return {Null} null
+  */
+
+	function SitePostType(postType, siteId, wpcom) {
+		_classCallCheck(this, SitePostType);
+
+		if (!siteId) {
+			throw new TypeError('`siteId` is not correctly defined');
+		}
+
+		if (!postType) {
+			throw new TypeError('`postType` is not correctly defined');
+		}
+
+		if (!(this instanceof SitePostType)) {
+			return new SitePostType(postType, siteId, wpcom);
+		}
+
+		this.wpcom = wpcom;
+
+		this._siteId = encodeURIComponent(siteId);
+		this._postType = encodeURIComponent(postType);
+		this._rootPath = '/sites/' + this._siteId + '/post-types/' + this._postType;
+	}
+
+	/**
+  * Get a list of taxonomies for the post type
+  *
+  * @param {Function} fn - callback function
+  * @return {Promise} Promise
+  */
+
+	_createClass(SitePostType, [{
+		key: 'taxonomiesList',
+		value: function taxonomiesList(fn) {
+			var termsPath = this._rootPath + '/taxonomies';
+			return this.wpcom.req.get(termsPath, fn);
+		}
+	}]);
+
+	return SitePostType;
+})();
+
+exports['default'] = SitePostType;
+module.exports = exports['default'];

--- a/dist/lib/site.post-type.js
+++ b/dist/lib/site.post-type.js
@@ -44,15 +44,16 @@ var SitePostType = (function () {
 	/**
   * Get a list of taxonomies for the post type
   *
+  * @param {Object} query - query object
   * @param {Function} fn - callback function
   * @return {Promise} Promise
   */
 
 	_createClass(SitePostType, [{
 		key: 'taxonomiesList',
-		value: function taxonomiesList(fn) {
+		value: function taxonomiesList(query, fn) {
 			var termsPath = this._rootPath + '/taxonomies';
-			return this.wpcom.req.get(termsPath, fn);
+			return this.wpcom.req.get(termsPath, query, fn);
 		}
 	}]);
 

--- a/lib/site.js
+++ b/lib/site.js
@@ -11,6 +11,7 @@ import SiteDomain from './site.domain';
 import SitePlugin from './site.plugin';
 import SiteSettings from './site.settings';
 import SiteTaxonomy from './site.taxonomy';
+import SitePostType from './site.post-type';
 import SiteWordAds from './site.wordads';
 import SiteWPComPlugin from './site.wpcom-plugin';
 import siteGetMethods from './runtime/site.get';
@@ -207,6 +208,16 @@ class Site {
 	 */
 	taxonomy( slug ) {
 		return new SiteTaxonomy( slug, this._id, this.wpcom );
+	}
+
+	/**
+	 * Create a `SitePostType` instance
+	 *
+	 * @param {String} [slug] - post type slug
+	 * @return {SitePostType} SitePostType instance
+	 */
+	postType( slug ) {
+		return new SitePostType( slug, this._id, this.wpcom );
 	}
 
 	/**

--- a/lib/site.post-type.js
+++ b/lib/site.post-type.js
@@ -1,0 +1,43 @@
+/**
+ * SitePostType class
+ */
+export default class SitePostType {
+	/**
+	 * Create a SitePostType instance
+	 *
+	 * @param {String} postType - post type
+	 * @param {String} siteId - site id
+	 * @param {WPCOM} wpcom - wpcom instance
+	 * @return {Null} null
+	 */
+	constructor( postType, siteId, wpcom ) {
+		if ( ! siteId ) {
+			throw new TypeError( '`siteId` is not correctly defined' );
+		}
+
+		if ( ! postType ) {
+			throw new TypeError( '`postType` is not correctly defined' );
+		}
+
+		if ( ! ( this instanceof SitePostType ) ) {
+			return new SitePostType( postType, siteId, wpcom );
+		}
+
+		this.wpcom = wpcom;
+
+		this._siteId = encodeURIComponent( siteId );
+		this._postType = encodeURIComponent( postType );
+		this._rootPath = `/sites/${ this._siteId }/post-types/${ this._postType }`;
+	}
+
+	/**
+	 * Get a list of taxonomies for the post type
+	 *
+	 * @param {Function} fn - callback function
+	 * @return {Promise} Promise
+	 */
+	taxonomiesList( fn ) {
+		const termsPath = `${ this._rootPath }/taxonomies`;
+		return this.wpcom.req.get( termsPath, fn );
+	}
+}

--- a/lib/site.post-type.js
+++ b/lib/site.post-type.js
@@ -33,11 +33,12 @@ export default class SitePostType {
 	/**
 	 * Get a list of taxonomies for the post type
 	 *
+	 * @param {Object} query - query object
 	 * @param {Function} fn - callback function
 	 * @return {Promise} Promise
 	 */
-	taxonomiesList( fn ) {
+	taxonomiesList( query, fn ) {
 		const termsPath = `${ this._rootPath }/taxonomies`;
-		return this.wpcom.req.get( termsPath, fn );
+		return this.wpcom.req.get( termsPath, query, fn );
 	}
 }

--- a/test/test.wpcom.site.post-type.js
+++ b/test/test.wpcom.site.post-type.js
@@ -1,0 +1,35 @@
+/**
+ * Module dependencies
+ */
+var util = require( './util' );
+var assert = require( 'assert' );
+
+/**
+ * site.postType
+ */
+describe( 'wpcom.site.postType', function() {
+	// Global instances
+	var wpcom = util.wpcom();
+	var site = wpcom.site( util.site() );
+	var postType = site.postType( 'post' );
+
+	describe( 'wpcom.site.postType.taxonomiesList', function() {
+		it( 'should return a list of taxonomies', function() {
+			return postType
+				.taxonomiesList()
+				.then( function( data ) {
+					var taxonomy = data.taxonomies[ 0 ];
+					assert.ok( data );
+					assert.equal( 'number', typeof data.found );
+					assert.ok( data.taxonomies.length >= 1 );
+					assert.equal( 'string', typeof taxonomy.name );
+					assert.equal( 'string', typeof taxonomy.label );
+					assert.equal( '[object Object]', Object.prototype.toString.call( taxonomy.labels ) );
+					assert.equal( 'string', typeof taxonomy.description );
+					assert.equal( 'boolean', typeof taxonomy.hierarchical );
+					assert.equal( 'boolean', typeof taxonomy.public );
+					assert.equal( '[object Object]', Object.prototype.toString.call( taxonomy.capabilities ) );
+				} );
+		} );
+	} );
+} );


### PR DESCRIPTION
This pull request seeks to add support for the `GET /sites/%s/post-types/%s/taxonomies` endpoint, accessible in wpcom.js via `wpcom.site( siteId ).postType( postType ).taxonomiesList()`.