### PR TITLE
SiteAdCreditVouchers: first implementation

### DIFF
--- a/lib/site.ad-credit-vouchers.js
+++ b/lib/site.ad-credit-vouchers.js
@@ -1,0 +1,63 @@
+
+/**
+ * SiteAdCreditVouchers methods
+ *
+ * @param {String} sid - site id
+ * @param {WPCOM} wpcom - wpcom instance
+ * @return {Null} null
+ */
+class SiteAdCreditVouchers {
+	constructor( sid, wpcom ) {
+		if ( ! sid ) {
+			throw new Error( '`site id` is not correctly defined' );
+		}
+
+		if ( ! ( this instanceof SiteAdCreditVouchers ) ) {
+			return new SiteAdCreditVouchers( sid, wpcom );
+		}
+
+		this.wpcom = wpcom;
+		this._sid = sid;
+		this.path = `/sites/${this._sid}/vouchers`;
+	}
+
+	/**
+	 * Get site vouchers list
+	 *
+	 * @param {Object} [query] - query object parameter
+	 * @param {Function} fn - callback function
+	 * @return {Function} request handler
+	 */
+	list( query = {}, fn ) {
+		query.apiNamespace = 'wpcom/v2';
+		return this.wpcom.req.get( this.path, query, fn );
+	}
+
+	/**
+	 * Get site voucher
+	 *
+	 * @param {String} serviceType - service type
+	 * @param {Object} [query] - query object parameter
+	 * @param {Function} fn - callback function
+	 * @return {Function} request handler
+	 */
+	get( serviceType, query = {}, fn ) {
+		query.apiNamespace = 'wpcom/v2';
+		return this.wpcom.req.get( `${ this.path }/${ serviceType }`, query, fn );
+	}
+
+	/**
+	 * Assign a new voucher to the site
+	 *
+	 * @param {String} serviceType - service type
+	 * @param {Object} [query] - query object parameter
+	 * @param {Function} fn - callback function
+	 * @return {Function} request handler
+	 */
+	assign( serviceType, query = {}, fn ) {
+		query.apiNamespace = 'wpcom/v2';
+		return this.wpcom.req.post( `${ this.path }/${ serviceType}/assign`, query, {}, fn );
+	}
+}
+
+export default SiteAdCreditVouchers;

--- a/lib/site.js
+++ b/lib/site.js
@@ -7,13 +7,15 @@ import Follow from './site.follow';
 import Media from './site.media';
 import Post from './site.post';
 import Tag from './site.tag';
+import SitePostType from './site.post-type';
 import SiteDomain from './site.domain';
 import SitePlugin from './site.plugin';
 import SiteSettings from './site.settings';
 import SiteTaxonomy from './site.taxonomy';
-import SitePostType from './site.post-type';
+import SiteAdCreditVouchers from './site.ad-credit-vouchers';
 import SiteWordAds from './site.wordads';
 import SiteWPComPlugin from './site.wpcom-plugin';
+
 import siteGetMethods from './runtime/site.get';
 import runtimeBuilder from './util/runtime-builder';
 import debugFactory from 'debug';
@@ -208,6 +210,15 @@ class Site {
 	 */
 	taxonomy( slug ) {
 		return new SiteTaxonomy( slug, this._id, this.wpcom );
+	}
+
+	/**
+	 * Create a `SiteAdCreditVouchers` instance
+	 *
+	 * @return {SiteAdCreditVouchers} SiteAdCreditVouchers instance
+	 */
+	adCreditVouchers() {
+		return new SiteAdCreditVouchers( this._id, this.wpcom );
 	}
 
 	/**


### PR DESCRIPTION
Add SiteAdCreditVouchers class to handle site vouchers endpoints.

### Site.adCreditVouchers()

Creates a new SiteAdCreditVouchers instance

```es6
const site = wpcom.site( 'mitestingblog.wordpress.com' );
const vouchers = site.vouchers();
```

### SiteAdCreditVouchers#list()

Get the whole vouchers list

```es6
wpcom
  .site( 'mitestingblog.wordpress.com' )
  .vouchers()
  .list()
    .then( list => console.log( list ); )
    .catch( err => console.error( err ); )
```

### SiteAdCreditVouchers#get( serviceType )

Get vouchers list by service type

```es6
wpcom
  .site( 'mitestingblog.wordpress.com' )
  .vouchers()
  .get( 'google-ad-credits' )
    .then( list => console.log( list ); )
    .catch( err => console.error( err ); )
```

### SiteAdCreditVouchers#add( serviceType )

Assign a voucher by service type

```es6
wpcom
  .site( 'testing.wordpress.com' )
  .adCreditVouchers()
  .assign( 'google-ad-credits' )
    .then( data => console.log( data ) )
    .catch( error => console.error( error ) );
```