### PR TITLE
Add marketing survey stuff

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,16 +6,18 @@ var requestHandler = require( 'wpcom-xhr-request' );
 /**
  * Local module dependencies.
  */
-var Me = require( './lib/me' );
-var Site = require( './lib/site' );
-var Domains = require( './lib/domains' );
-var Domain = require( './lib/domain' );
-var Users = require( './lib/users' );
 var Batch = require( './lib/batch' );
+var Domain = require( './lib/domain' );
+var Domains = require( './lib/domains' );
+var Marketing = require( './lib/marketing' );
+var Me = require( './lib/me' );
+var Pinghub = require( './lib/util/pinghub' );
 var Plans = require( './lib/plans' );
 var Req = require( './lib/util/request' );
+var Site = require( './lib/site' );
+var Users = require( './lib/users' );
+
 var sendRequest = require( './lib/util/send-request' );
-var Pinghub = require( './lib/util/pinghub' );
 var debug = require( 'debug' )( 'wpcom' );
 
 /**
@@ -78,6 +80,15 @@ function WPCOM( token, reqHandler ) {
 	// Default api version;
 	this.apiVersion = '1.1';
 }
+
+/**
+ * Return `Marketing` object instance
+ *
+ * @return {Marketing} Marketing instance
+ */
+WPCOM.prototype.marketing = function() {
+	return new Marketing( this );
+};
 
 /**
  * Return `Me` object instance

--- a/lib/marketing.js
+++ b/lib/marketing.js
@@ -1,0 +1,30 @@
+/**
+ * Local module dependencies.
+ */
+import MarketingSurvey from './marketing.survey';
+
+export default class Marketing {
+	/**
+	 * `Marketing` constructor.
+	 *
+	 * @param {WPCOM} wpcom - wpcom instance
+	 * @return {Undefined} undefined
+	 */
+	constructor( wpcom ) {
+		if ( ! ( this instanceof Marketing ) ) {
+			return new Marketing( wpcom );
+		}
+		this.wpcom = wpcom;
+	}
+
+	/**
+	 * Return `MarketingSurvey` object instance
+	 *
+	 * @param {String} id - survey idetification
+	 * @param {String} [siteId] - site identification
+	 * @return {MarketingSurvey} MarketingSurvey instance
+	 */
+	survey( id, siteId ) {
+		return new MarketingSurvey( id, siteId, this.wpcom );
+	};
+}

--- a/lib/marketing.survey.js
+++ b/lib/marketing.survey.js
@@ -1,0 +1,77 @@
+/**
+ * Module dependencies.
+ */
+import WPCOM from '../';
+
+/**
+ * Module vars
+ */
+const root = '/marketing/survey';
+
+export default class MarketingSurvey {
+	/**
+	 * `MarketingSurvey` constructor.
+	 *
+	 * @param {String} id - survey identification
+	 * @param {String} [siteId] - site identification
+	 * @param {WPCOM} wpcom - wpcom instance
+	 * @return {Undefined} undefined
+	 */
+	constructor( id, siteId, wpcom ) {
+		if ( ! id ) {
+			throw new TypeError( '`id` survey is not correctly defined' );
+		}
+
+		if ( ! ( this instanceof MarketingSurvey ) ) {
+			return new MarketingSurvey( id, siteId, wpcom );
+		}
+
+		if ( siteId instanceof WPCOM ) {
+			this.wpcom = siteId;
+		} else {
+			this._siteId = siteId;
+			this.wpcom = wpcom;
+		}
+
+		this._id = id;
+		this._responses = {};
+	}
+
+	setSiteId( siteId ) {
+		this._siteId = siteId;
+		return this;
+	}
+
+	addResponse( key, value ) {
+		this._responses = Object.assign(
+			{},
+			this._responses,
+			{ [ key ]: value }
+		);
+		return this;
+	}
+
+	addResponses( responses ) {
+		this._responses = Object.assign(
+			{},
+			this._responses,
+			responses
+		);
+		return this;
+	}
+
+	/**
+	 * Submit a marketing survey.
+	 *
+	 * @param {Object} [query] - query object parameter
+	 * @param {Object} [body] - body object parameter
+	 * @param {Function} [fn] - callback function
+	 * @return {Promise} Promise
+	 */
+	submit( query = {}, body = {}, fn ) {
+		body.survey_id = this._id;
+		body.site_id = body.site_id || this._siteId;
+		body.survey_responses = body.survey_responses || this._responses;
+		return this.wpcom.req.post( `${ root }`, query, body, fn );
+	}
+}


### PR DESCRIPTION
Add code to that allows us handle marketing surveys through of the `/marketing/survey` endpoint.

### wpcom#Marketing()

Creates a `Marketing` instance

### Marketing#Survey( id, [siteId] )

Creates a `MarketingSurvey` instance with the given survey `id` and `siteId` (optional).

### MarketingSurvey#setSiteId( siteId )

Set site id to be used when a survey is submitted.

### MarketingSurvey#addResponse( key, value )

Add a par `key`-`value` to the survey responses.

### MarketingSurvey#addResponses( object );

Add an object of responses to survey.

### MarketingSurvey#submit( [body[ )

Submit the marketing survey

```es6
import wpcom from 'wpcom';

var survey = wpcom.marketing().survey( 'best-cartoons', 9073334 );

// add a response to the survey
surver.addResponse( 'adventure-time', 'Adventure Time' );

// Add other responses
survay.addResponses( {
  'gumball': 'The Amazing World of Gumball',
  'gravity-falls': 'Gravity Falls'
} );

// Finally send the survey
survey.submit()
  .then( resp => console.log( respo ) )
  .catch( err => console.error( err ) );
```