### PR TITLE
rename `ad-credit-vouchers` to `credit-voucher`

### DIFF
--- a/lib/site.credit-vouchers.js
+++ b/lib/site.credit-vouchers.js
@@ -1,19 +1,19 @@
 
 /**
- * SiteAdCreditVouchers methods
+ * SiteCreditVouchers methods
  *
  * @param {String} sid - site id
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */
-class SiteAdCreditVouchers {
+class SiteCreditVouchers {
 	constructor( sid, wpcom ) {
 		if ( ! sid ) {
 			throw new Error( '`site id` is not correctly defined' );
 		}
 
-		if ( ! ( this instanceof SiteAdCreditVouchers ) ) {
-			return new SiteAdCreditVouchers( sid, wpcom );
+		if ( ! ( this instanceof SiteCreditVouchers ) ) {
+			return new SiteCreditVouchers( sid, wpcom );
 		}
 
 		this.wpcom = wpcom;
@@ -30,6 +30,7 @@ class SiteAdCreditVouchers {
 	 */
 	list( query = {}, fn ) {
 		query.apiNamespace = 'wpcom/v2';
+		console.log( `-> query -> `, query );
 		return this.wpcom.req.get( this.path, query, fn );
 	}
 
@@ -60,4 +61,4 @@ class SiteAdCreditVouchers {
 	}
 }
 
-export default SiteAdCreditVouchers;
+export default SiteCreditVouchers;

--- a/lib/site.js
+++ b/lib/site.js
@@ -12,7 +12,7 @@ import SiteDomain from './site.domain';
 import SitePlugin from './site.plugin';
 import SiteSettings from './site.settings';
 import SiteTaxonomy from './site.taxonomy';
-import SiteAdCreditVouchers from './site.ad-credit-vouchers';
+import SiteCreditVouchers from './site.credit-vouchers';
 import SiteWordAds from './site.wordads';
 import SiteWPComPlugin from './site.wpcom-plugin';
 
@@ -213,12 +213,12 @@ class Site {
 	}
 
 	/**
-	 * Create a `SiteAdCreditVouchers` instance
+	 * Create a `SiteCreditVouchers` instance
 	 *
-	 * @return {SiteAdCreditVouchers} SiteAdCreditVouchers instance
+	 * @return {SiteCreditVouchers} SiteCreditVouchers instance
 	 */
-	adCreditVouchers() {
-		return new SiteAdCreditVouchers( this._id, this.wpcom );
+	creditVouchers() {
+		return new SiteCreditVouchers( this._id, this.wpcom );
 	}
 
 	/**


### PR DESCRIPTION
In order to remove `ad` from the stuff I decided rename methods, files, etc.

cc @rralian 