### PR TITLE
Use ES6 `export` keyword consistently

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ const DEFAULT_ASYNC_TIMEOUT = 30000;
  * @param {Function} [reqHandler] - function Request Handler
  * @return {WPCOM} wpcom instance
  */
-function WPCOM( token, reqHandler ) {
+export default function WPCOM( token, reqHandler ) {
 	if ( ! ( this instanceof WPCOM ) ) {
 		return new WPCOM( token, reqHandler );
 	}
@@ -214,8 +214,3 @@ if ( ! Promise.prototype.timeout ) {
 		] );
 	};
 }
-
-/**
- * Expose `WPCOM` module
- */
-module.exports = WPCOM;

--- a/lib/me.connected-application.js
+++ b/lib/me.connected-application.js
@@ -1,6 +1,6 @@
 const root = '/me/connected-applications/';
 
-class MeConnectedApp {
+export default class MeConnectedApp {
 
 	/**
 	 * `MeConnectedApp` constructor.
@@ -40,8 +40,3 @@ class MeConnectedApp {
 		return this.wpcom.req.del( root + this._id + '/delete', query, fn );
 	}
 }
-
-/**
-* Expose `MeConnectedApp` module
-*/
-module.exports = MeConnectedApp;

--- a/lib/me.js
+++ b/lib/me.js
@@ -13,7 +13,7 @@ import MeTwoStep from './me.two-step';
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */
-function Me( wpcom ) {
+export default function Me( wpcom ) {
 	if ( ! ( this instanceof Me ) ) {
 		return new Me( wpcom );
 	}
@@ -177,8 +177,3 @@ Me.prototype.twoStep = function() {
 Me.prototype.keyringConnection = function( id ) {
 	return new MeKeyringConnection( id, this.wpcom );
 };
-
-/**
- * Expose `Me` module
- */
-module.exports = Me;

--- a/lib/me.keyring-connection.js
+++ b/lib/me.keyring-connection.js
@@ -1,6 +1,6 @@
 const root = '/me/keyring-connections/';
 
-class KeyringConnection {
+export default class KeyringConnection {
 
 	/**
 	 * `KeyringConnection` constructor.
@@ -40,8 +40,3 @@ class KeyringConnection {
 		return this.wpcom.req.del( root + this._id + '/delete', query, fn );
 	}
 }
-
-/**
-* Expose `KeyringConnection` module
-*/
-module.exports = KeyringConnection;

--- a/lib/me.publicize-connection.js
+++ b/lib/me.publicize-connection.js
@@ -1,6 +1,6 @@
 const root = '/me/publicize-connections/';
 
-class PublicizeConnection {
+export default class PublicizeConnection {
 	/**
 	* `PublicizeConnection` constructor.
 	*
@@ -63,8 +63,3 @@ class PublicizeConnection {
 		return this.wpcom.req.del( root + this._id + '/delete', query, fn );
 	}
 }
-
-/**
-* Expose `PublicizeConnection` module
-*/
-module.exports = PublicizeConnection;

--- a/lib/me.settings.js
+++ b/lib/me.settings.js
@@ -22,7 +22,7 @@ import MeSettingsPassword from './me.settings.password';
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */
-function MeSettings( wpcom ) {
+export default function MeSettings( wpcom ) {
 	if ( ! ( this instanceof MeSettings ) ) {
 		return new MeSettings( wpcom );
 	}
@@ -83,8 +83,3 @@ MeSettings.prototype.profileLinks = function() {
 MeSettings.prototype.password = function() {
 	return new MeSettingsPassword( this.wpcom );
 };
-
-/**
- * Expose `MeSettings` module
- */
-module.exports = MeSettings;

--- a/lib/me.settings.password.js
+++ b/lib/me.settings.password.js
@@ -1,6 +1,6 @@
 const root = '/me/settings/password/';
 
-class MeSettingsPassword {
+export default class MeSettingsPassword {
 
 	/**
 	 * `MeSettingsPassword` constructor.
@@ -27,8 +27,3 @@ class MeSettingsPassword {
 		return this.wpcom.req.post( root + 'validate', query, { password: password }, fn );
 	}
 }
-
-/**
-* Expose `MeSettingsPassword` module
-*/
-module.exports = MeSettingsPassword;

--- a/lib/me.settings.profile-links.js
+++ b/lib/me.settings.profile-links.js
@@ -9,7 +9,7 @@ const root = '/me/settings/profile-links';
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */
-function ProfileLinks( wpcom ) {
+export default function ProfileLinks( wpcom ) {
 	if ( ! ( this instanceof ProfileLinks ) ) {
 		return new ProfileLinks( wpcom );
 	}
@@ -106,9 +106,3 @@ ProfileLinks.prototype.del = function( slug, query, fn ) {
 
 // Create `delete` alias
 ProfileLinks.prototype.delete = ProfileLinks.prototype.del;
-
-/**
- * Expose `ProfileLinks` module
- */
-
-module.exports = ProfileLinks;

--- a/lib/me.two-step.js
+++ b/lib/me.two-step.js
@@ -5,7 +5,7 @@ import MeTwoStepSMS from './me.two-step.sms';
 
 const root = '/me/two-step/';
 
-class MeTwoStep {
+export default class MeTwoStep {
 
 	/**
 	 * `MeTwoStep` constructor.
@@ -40,8 +40,3 @@ class MeTwoStep {
 		return new MeTwoStepSMS( this.wpcom );
 	};
 }
-
-/**
-* Expose `MeTwoStep` module
-*/
-module.exports = MeTwoStep;

--- a/lib/me.two-step.sms.js
+++ b/lib/me.two-step.sms.js
@@ -1,6 +1,6 @@
 const root = '/me/two-step/sms/';
 
-class MeTwoStepSMS {
+export default class MeTwoStepSMS {
 
 	/**
 	 * `MeTwoStepSMS` constructor.
@@ -26,8 +26,3 @@ class MeTwoStepSMS {
 		return this.wpcom.req.post( root + 'new', query, fn );
 	}
 }
-
-/**
-* Expose `MeTwoStepSMS` module
-*/
-module.exports = MeTwoStepSMS;

--- a/lib/site.category.js
+++ b/lib/site.category.js
@@ -6,7 +6,7 @@
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */
-function Category( slug, sid, wpcom ) {
+export default function Category( slug, sid, wpcom ) {
 	if ( ! sid ) {
 		throw new Error( '`site id` is not correctly defined' );
 	}
@@ -78,8 +78,3 @@ Category.prototype.delete = Category.prototype.del = function( query, fn ) {
 	var path = '/sites/' + this._sid + '/categories/slug:' + this._slug + '/delete';
 	return this.wpcom.req.del( path, query, fn );
 };
-
-/**
- * Expose `Category` module
- */
-module.exports = Category;

--- a/lib/site.comment.js
+++ b/lib/site.comment.js
@@ -12,7 +12,7 @@ var commentLike = require( './site.comment.like' );
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */
-function Comment( cid, pid, sid, wpcom ) {
+export default function Comment( cid, pid, sid, wpcom ) {
 	if ( ! sid ) {
 		throw new Error( '`site id` is not correctly defined' );
 	}
@@ -152,8 +152,3 @@ Comment.prototype.likesList = function( query, fn ) {
 	var path = '/sites/' + this._sid + '/comments/' + this._cid + '/likes';
 	return this.wpcom.req.get( path, query, fn );
 };
-
-/**
- * Expose `Comment` module
- */
-module.exports = Comment;

--- a/lib/site.comment.like.js
+++ b/lib/site.comment.like.js
@@ -6,7 +6,7 @@
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */
-function CommentLike( cid, sid, wpcom ) {
+export default function CommentLike( cid, sid, wpcom ) {
 	if ( ! sid ) {
 		throw new Error( '`site id` is not correctly defined' );
 	}
@@ -61,8 +61,3 @@ CommentLike.prototype.delete = function( query, fn ) {
 	var path = '/sites/' + this._sid + '/comments/' + this._cid + '/likes/mine/delete';
 	return this.wpcom.req.del( path, query, fn );
 };
-
-/**
- * Expose `CommentLike` module
- */
-module.exports = CommentLike;

--- a/lib/site.follow.js
+++ b/lib/site.follow.js
@@ -5,7 +5,7 @@
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */
-function Follow( site_id, wpcom ) {
+export default function Follow( site_id, wpcom ) {
 	if ( ! site_id ) {
 		throw new Error( '`site id` is not correctly defined' );
 	}
@@ -57,8 +57,3 @@ Follow.prototype.del = function( query, fn ) {
 	var path = '/sites/' + this._sid + '/follows/mine/delete';
 	return this.wpcom.req.del( path, query, null, fn );
 };
-
-/**
- * Expose `Follow` module
- */
-module.exports = Follow;

--- a/lib/site.media.js
+++ b/lib/site.media.js
@@ -12,7 +12,7 @@ var debug = require( 'debug' )( 'wpcom:media' );
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */
-function Media( id, sid, wpcom ) {
+export default function Media( id, sid, wpcom ) {
 	if ( ! ( this instanceof Media ) ) {
 		return new Media( id, sid, wpcom );
 	}
@@ -175,8 +175,3 @@ Media.prototype.delete = Media.prototype.del = function( query, fn ) {
 	var path = '/sites/' + this._sid + '/media/' + this._id + '/delete';
 	return this.wpcom.req.del( path, query, fn );
 };
-
-/**
- * Expose `Media` module
- */
-module.exports = Media;

--- a/lib/site.post.like.js
+++ b/lib/site.post.like.js
@@ -6,7 +6,7 @@
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */
-function Like( pid, sid, wpcom ) {
+export default function Like( pid, sid, wpcom ) {
 	if ( ! sid ) {
 		throw new Error( '`site id` is not correctly defined' );
 	}
@@ -59,8 +59,3 @@ Like.prototype.delete = function( query, fn ) {
 	var path = '/sites/' + this._sid + '/posts/' + this._pid + '/likes/mine/delete';
 	return this.wpcom.req.del( path, query, fn );
 };
-
-/**
- * Expose `Like` module
- */
-module.exports = Like;

--- a/lib/site.post.reblog.js
+++ b/lib/site.post.reblog.js
@@ -6,7 +6,7 @@
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */
-function Reblog( pid, sid, wpcom ) {
+export default function Reblog( pid, sid, wpcom ) {
 	if ( ! sid ) {
 		throw new Error( '`site id` is not correctly defined' );
 	}
@@ -81,8 +81,3 @@ Reblog.prototype.to = function( dest, note, fn ) {
 
 	return this.add( { note: note, destination_site_id: dest }, fn );
 };
-
-/**
- * Expose `Reblog` module
- */
-module.exports = Reblog;

--- a/lib/site.tag.js
+++ b/lib/site.tag.js
@@ -6,7 +6,7 @@
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */
-function Tag( slug, sid, wpcom ) {
+export default function Tag( slug, sid, wpcom ) {
 	if ( ! sid ) {
 		throw new Error( '`site id` is not correctly defined' );
 	}
@@ -78,8 +78,3 @@ Tag.prototype.delete = Tag.prototype.del = function( query, fn ) {
 	var path = '/sites/' + this._sid + '/tags/slug:' + this._slug + '/delete';
 	return this.wpcom.req.del( path, query, fn );
 };
-
-/**
- * Expose `Tag` module
- */
-module.exports = Tag;

--- a/lib/site.wordads.earnings.js
+++ b/lib/site.wordads.earnings.js
@@ -19,7 +19,7 @@
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */
-function SiteWordAdsEarnings( sid, wpcom ) {
+export default function SiteWordAdsEarnings( sid, wpcom ) {
 	if ( ! ( this instanceof SiteWordAdsEarnings ) ) {
 		return new SiteWordAdsEarnings( sid, wpcom );
 	}
@@ -48,9 +48,3 @@ function SiteWordAdsEarnings( sid, wpcom ) {
 SiteWordAdsEarnings.prototype.get = function( query, fn ) {
 	return this.wpcom.req.get( '/sites/' + this._sid + '/wordads/earnings', query, fn );
 };
-
-/**
- * Expose `SiteWordAdsEarnings` module
- */
-
-module.exports = SiteWordAdsEarnings;

--- a/lib/site.wordads.js
+++ b/lib/site.wordads.js
@@ -26,7 +26,7 @@ import SiteWordAdsTOS from './site.wordads.tos';
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */
-function SiteWordAds( sid, wpcom ) {
+export default function SiteWordAds( sid, wpcom ) {
 	if ( ! ( this instanceof SiteWordAds ) ) {
 		return new SiteWordAds( sid, wpcom );
 	}
@@ -87,8 +87,3 @@ SiteWordAds.prototype.earnings = function() {
 SiteWordAds.prototype.tos = function() {
 	return new SiteWordAdsTOS( this._sid, this.wpcom );
 };
-
-/**
- * Expose `SiteWordAds` module
- */
-module.exports = SiteWordAds;

--- a/lib/site.wordads.settings.js
+++ b/lib/site.wordads.settings.js
@@ -19,7 +19,7 @@
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */
-function SiteWordAdsSettings( sid, wpcom ) {
+export default function SiteWordAdsSettings( sid, wpcom ) {
 	if ( ! ( this instanceof SiteWordAdsSettings ) ) {
 		return new SiteWordAdsSettings( sid, wpcom );
 	}
@@ -73,8 +73,3 @@ SiteWordAdsSettings.prototype.update = function( query, body, fn ) {
 	var path = '/sites/' + this._sid + '/wordads/settings';
 	return this.wpcom.req.post( path, query, body, fn );
 };
-
-/**
- * Expose `SiteWordAdsSettings` module
- */
-module.exports = SiteWordAdsSettings;

--- a/lib/site.wordads.tos.js
+++ b/lib/site.wordads.tos.js
@@ -18,7 +18,7 @@
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */
-function SiteWordAdsTOS( sid, wpcom ) {
+export default function SiteWordAdsTOS( sid, wpcom ) {
 	if ( ! ( this instanceof SiteWordAdsTOS ) ) {
 		return new SiteWordAdsTOS( sid, wpcom );
 	}
@@ -92,8 +92,3 @@ SiteWordAdsTOS.prototype.sign = function( query, fn ) {
 	var path = '/sites/' + this._sid + '/wordads/tos';
 	return this.wpcom.req.post( path, query, { tos: 'signed' }, fn );
 };
-
-/**
- * Expose `SiteWordAdsTOS` module
- */
-module.exports = SiteWordAdsTOS;

--- a/lib/users.js
+++ b/lib/users.js
@@ -4,7 +4,7 @@
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */
-function Users( wpcom ) {
+export default function Users( wpcom ) {
 	if ( ! ( this instanceof Users ) ) {
 		return new Users( wpcom );
 	}
@@ -22,8 +22,3 @@ function Users( wpcom ) {
 Users.prototype.suggest = function( query, fn ) {
 	return this.wpcom.req.get( '/users/suggest', query, fn );
 };
-
-/**
- * Expose `Users` module
- */
-module.exports = Users;

--- a/lib/util/pinghub.js
+++ b/lib/util/pinghub.js
@@ -13,7 +13,7 @@ var debug = require('debug')('wpcom:pinghub');
  * @return {null} null
  * @api public
  */
-function Pinghub( wpcom ) {
+export default function Pinghub( wpcom ) {
 	if ( ! ( this instanceof Pinghub ) ) {
 		return new Pinghub( wpcom );
 	}
@@ -75,8 +75,3 @@ Pinghub.prototype.remove = function( path ) {
 	debug("remove", path);
 	delete this.conns[path];
 };
-
-/**
- * Expose `Pinghub` module
- */
-module.exports = Pinghub;

--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -7,7 +7,7 @@ var sendRequest = require( './send-request' );
  * Expose `Request` module
  * @param {WPCOM} wpcom - wpcom instance
  */
-function Req( wpcom ) {
+export default function Req( wpcom ) {
 	this.wpcom = wpcom;
 }
 
@@ -75,8 +75,3 @@ Req.prototype.del = function( params, query, fn ) {
 
 	return this.post( params, query, null, fn );
 };
-
-/**
- * Expose module
- */
-module.exports = Req;

--- a/lib/util/send-request.js
+++ b/lib/util/send-request.js
@@ -14,7 +14,7 @@ var debug_res = require( 'debug' )( 'wpcom:send-request:res' );
  * @param {Function} fn - callback function
  * @return {Function} request handler
  */
-module.exports = function( params, query, body, fn ) {
+export default function sendRequest( params, query, body, fn ) {
 	// `params` can be just the path ( String )
 	params = 'string' === typeof params ? { path: params } : params;
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-eslint": "^4.1.6",
     "eslint": "^1.10.1",
     "mocha": "^2.3.4",
-    "n8-make": "^1.1.0",
+    "n8-make": "^1.3.0",
     "webpack": "^1.12.1",
     "wpcom-oauth-cors": "^1.0.0",
     "wpcom-proxy-request": "^2.0.0"


### PR DESCRIPTION
`n8-make` v1.3.0 adds the ["add-module-exports"](https://www.npmjs.com/package/babel-plugin-add-module-exports) babel plugin by default,
which allows us to use proper ES6 `export` syntax and
have it properly work with the Node.js module system still.