### PR TITLE
Improve compiling process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,14 +52,14 @@ test:
 		--compilers js:babel-register \
 		test/
 
-test-all: build
+test-all:
 	@$(MOCHA) \
 		--timeout 120s \
 		--slow 3s \
 		--bail \
 		--reporter spec \
 		--compilers js:babel-register \
-		test/
+		test
 
 webapp:
 	@$(WEBPACK) -p --config webapp/webpack.config.js

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 THIS_MAKEFILE_PATH:=$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))
 THIS_DIR:=$(shell cd $(dir $(THIS_MAKEFILE_PATH));pwd)
 
+ROOT := lib index.js
 include $(shell node -e "require('n8-make')")
 
 # BIN directory

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 THIS_MAKEFILE_PATH:=$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))
 THIS_DIR:=$(shell cd $(dir $(THIS_MAKEFILE_PATH));pwd)
 
+
 ROOT := lib index.js
 include $(shell node -e "require('n8-make')")
 
@@ -22,9 +23,13 @@ NPM ?= $(NODE) $(shell which npm)
 MOCHA ?= $(NODE) $(BIN)/mocha
 WEBPACK ?= $(NODE) $(BIN)/webpack
 
-standalone: build/wpcom.js
+standalone: compile build/wpcom.js
 
-build/wpcom.js: $(COMPILED_FILES)
+compile:
+	make build --jobs=8
+
+build/wpcom.js:
+	@$(WEBPACK) -p --config ./webpack.config.js
 
 install: node_modules
 
@@ -37,11 +42,7 @@ lint: node_modules/eslint node_modules/babel-eslint
 
 eslint: lint
 
-example-server:
-	cd examples/server/; $(NPM) install
-	$(NODE) examples/server/index.js
-
-test: build
+test:
 	@$(MOCHA) \
 		--timeout 120s \
 		--slow 3s \
@@ -59,26 +60,6 @@ test-all: build
 		--reporter spec \
 		--compilers js:babel-register \
 		test/
-
-publish: clean standalone
-	$(NPM) publish
-
-# testing client app
-test-app: build build/test/testing-source.js
-	mkdir -p webapp/tests
-	cp test/fixture.json build/test/
-	cp test/config.json build/test/
-	cp test/util.js build/test/
-	cp ./node_modules/mocha/mocha.js $(TESTAPP_DIR)
-	cp ./node_modules/mocha/mocha.css $(TESTAPP_DIR)
-	@$(WEBPACK) -p --config ./webpack.tests.config.js
-
-run-test-app: build test-app
-	cd $(TESTAPP_DIR); serve -p $(TESTAPP_PORT)
-
-build/test/testing-source.js: ${JS_TESTING_FILES}
-	mkdir -p build/test/
-	cat > $@ $^
 
 webapp:
 	@$(WEBPACK) -p --config webapp/webpack.config.js
@@ -101,4 +82,5 @@ deploy: test-app webapp
 	git push origin gh-pages
 	git checkout -
 
-.PHONY: standalone example-server test test-all publish node_modules lint eslint webapp
+
+.PHONY: standalone test test-all node_modules lint eslint webapp compile

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ test: build
 		--grep "$(FILTER)" \
 		--bail \
 		--reporter spec \
-		build/test
+		--compilers js:babel-register \
+		test/
 
 test-all: build
 	@$(MOCHA) \
@@ -56,7 +57,8 @@ test-all: build
 		--slow 3s \
 		--bail \
 		--reporter spec \
-		build/test
+		--compilers js:babel-register \
+		test/
 
 publish: clean standalone
 	$(NPM) publish

--- a/lib/me.settings.js
+++ b/lib/me.settings.js
@@ -9,16 +9,6 @@ import MeSettingsPassword from './me.settings.password';
  *
  * Use a `WPCOM#Me` instance to create a new `MeSettings` instance.
  *
- * *Example:*
- *    // Require `wpcom-unpublished` library
- *    var wpcomUnpublished = require( 'wpcom-unpublished' );
- *
- *    // Create a `wpcomUnpublished` instance
- *    var wpcom = wpcomUnpublished();
- *
- *    // Create a `MeSettings` instance
- *    var settings = wpcom.me().settings();
- *
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null
  */

--- a/lib/site.comment.js
+++ b/lib/site.comment.js
@@ -1,7 +1,7 @@
 /**
  * Module dependencies.
  */
-var commentLike = require( './site.comment.like' );
+import commentLike from './site.comment.like';
 
 /**
  * Comment methods

--- a/lib/site.media.js
+++ b/lib/site.media.js
@@ -1,8 +1,10 @@
 /**
  * Module dependencies.
  */
-var fs = require( 'fs' );
-var debug = require( 'debug' )( 'wpcom:media' );
+const fs = require( 'fs' );
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'wpcom:media' );
 
 /**
  * Media methods

--- a/lib/site.wordads.earnings.js
+++ b/lib/site.wordads.earnings.js
@@ -1,20 +1,6 @@
 /**
  * `SiteWordAdsEarnings` constructor.
  *
- * *Example:*
- *    // Require `wpcom-unpublished` library
- *    import wpcomUnpublished from 'wpcom-unpublished';
- *
- *    // Create a `wpcomUnpublished` instance
- *    var wpcom = wpcomUnpublished();
- *
- *    // Create a `SiteWordAdsEarnings` instance
- *    var wordAds = wpcom
- *      .site( 'my-blog.wordpress.com' )
- *      .wordAds()
- *      .earnings();
- *
- *
  * @param {String} sid - site identifier
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null

--- a/lib/site.wordads.js
+++ b/lib/site.wordads.js
@@ -10,18 +10,6 @@ import SiteWordAdsTOS from './site.wordads.tos';
  *
  * Use a `WPCOM#Me` instance to create a new `SiteWordAds` instance.
  *
- * *Example:*
- *    // Require `wpcom-unpublished` library
- *    import wpcomUnpublished from 'wpcom-unpublished';
- *
- *    // Create a `wpcomUnpublished` instance
- *    var wpcom = wpcomUnpublished();
- *
- *    // Create a `SiteWordAds` instance
- *    var wordAds = wpcom
- *      .site( 'my-blog.wordpress.com' )
- *      .wordAds();
- *
  * @param {String} sid - site identifier
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null

--- a/lib/site.wordads.settings.js
+++ b/lib/site.wordads.settings.js
@@ -1,20 +1,6 @@
 /**
  * `SiteWordAdsSettings` constructor.
  *
- * *Example:*
- *    // Require `wpcom-unpublished` library
- *    import wpcomUnpublished from 'wpcom-unpublished';
- *
- *    // Create a `wpcomUnpublished` instance
- *    var wpcom = wpcomUnpublished();
- *
- *    // Create a `SiteWordAdsSettings` instance
- *    var wordAds = wpcom
- *      .site( 'my-blog.wordpress.com' )
- *      .wordAds()
- *      .settings();
- *
- *
  * @param {String} sid - site identifier
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null

--- a/lib/site.wordads.tos.js
+++ b/lib/site.wordads.tos.js
@@ -1,19 +1,6 @@
 /**
  * `SiteWordAdsTOS` constructor.
  *
- * *Example:*
- *    // Require `wpcom-unpublished` library
- *    import wpcomUnpublished from 'wpcom-unpublished';
- *
- *    // Create a `wpcomUnpublished` instance
- *    var wpcom = wpcomUnpublished();
- *
- *    // Create a `SiteWordAdsTOS` instance
- *    var wordAds = wpcom
- *      .site( 'my-blog.wordpress.com' )
- *      .wordAds()
- *      .tos();
- *
  * @param {String} sid - site identifier
  * @param {WPCOM} wpcom - wpcom instance
  * @return {Null} null

--- a/lib/util/pinghub.js
+++ b/lib/util/pinghub.js
@@ -1,10 +1,9 @@
-
 /**
  * Module dependencies.
  */
+import debugFactory from 'debug';
 
-var debug = require('debug')('wpcom:pinghub');
-
+const debug = debugFactory( 'wpcom:pinghub' );
 
 /**
  * Create a `Pinghub` instance
@@ -25,25 +24,25 @@ export default function Pinghub( wpcom ) {
 /**
  * Open a websocket to Pinghub
  *
- * @param {String} path
- * @param {Function} fn
+ * @param {String} path - request path
+ * @param {Function} fn - callback function
  * @api public
  */
 Pinghub.prototype.connect = function( path, fn ) {
-	debug("connect", path, fn);
-	var pinghub = this,
+	debug( 'connect', path, fn );
+	let pinghub = this,
 		params = {
 			action: 'connect',
 			path: '/pinghub' + path
 		},
 		errorCallback = function() {}, // we want an xhr, not a promise
 		xhr = this.conns[path] = this.wpcom.req.get( params, errorCallback );
-	xhr.onload = function(e) {
-		debug( "onload", path, e );
+	xhr.onload = function( e ) {
+		debug( 'onload', path, e );
 		fn( null, e );
 	};
-	xhr.onerror = xhr.onabort = xhr.onclose = function(e) {
-		debug( "onerror", path, e );
+	xhr.onerror = xhr.onabort = xhr.onclose = function( e ) {
+		debug( 'onerror', path, e );
 		pinghub.remove( path );
 		fn( e, null );
 	};
@@ -52,12 +51,12 @@ Pinghub.prototype.connect = function( path, fn ) {
 /**
  * Close a websocket connection (unsubscribe)
  *
- * @param {String} path
+ * @param {String} path - request path
  * @api public
  */
 Pinghub.prototype.disconnect = function( path ) {
-	debug("disconnect", path);
-	var params = {
+	debug( 'disconnect', path );
+	let params = {
 			action: 'disconnect',
 			path: '/pinghub' + path
 		},
@@ -72,6 +71,6 @@ Pinghub.prototype.disconnect = function( path ) {
  * @api private
  */
 Pinghub.prototype.remove = function( path ) {
-	debug("remove", path);
-	delete this.conns[path];
+	debug( 'remove', path );
+	delete this.conns[ path ];
 };

--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -1,7 +1,7 @@
 /**
  * Module dependencies.
  */
-var sendRequest = require( './send-request' );
+import sendRequest from './send-request';
 
 /**
  * Expose `Request` module

--- a/lib/util/send-request.js
+++ b/lib/util/send-request.js
@@ -1,9 +1,11 @@
 /**
  * Module dependencies
  */
-var qs = require( 'qs' );
-var debug = require( 'debug' )( 'wpcom:send-request' );
-var debug_res = require( 'debug' )( 'wpcom:send-request:res' );
+import qs from 'qs';
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'wpcom:send-request' );
+const debug_res = debugFactory( 'wpcom:send-request:res' );
 
 /**
  * Request to WordPress REST API

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   ],
   "repository": "git@github.com:Automattic/wpcom.js.git",
   "license": "MIT",
+  "babel": {
+    "presets": [ "es2015", "stage-2" ]
+  },
   "dependencies": {
     "babel-runtime": "^6.9.2",
     "debug": "^2.2.0",
@@ -32,6 +35,9 @@
   },
   "devDependencies": {
     "babel-eslint": "^4.1.6",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-stage-2": "^6.11.0",
+    "babel-register": "^6.9.0",
     "eslint": "^1.10.1",
     "n8-make": "git://github.com/retrofox/n8-make.git#master",
     "mocha": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "devDependencies": {
     "babel-eslint": "^4.1.6",
     "eslint": "^1.10.1",
-    "mocha": "^2.3.4",
-    "n8-make": "^1.3.0",
+    "n8-make": "git://github.com/retrofox/n8-make.git#master",
+    "mocha": "^2.5.3",
     "webpack": "^1.12.1",
     "wpcom-oauth-cors": "^1.0.0",
     "wpcom-proxy-request": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "author": "Automattic, Inc.",
   "scripts": {
-    "prepublish": "make build"
+    "prepublish": "make standalone"
   },
   "contributors": [
     "Damian Suarez <rdsuarez@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "babel-preset-stage-2": "^6.11.0",
     "babel-register": "^6.9.0",
     "eslint": "^1.10.1",
-    "n8-make": "git://github.com/retrofox/n8-make.git#master",
     "mocha": "^2.5.3",
-    "webpack": "^1.12.1",
+    "n8-make": "1.4.0",
+    "webpack": "^1.13.1",
     "wpcom-oauth-cors": "^1.0.0",
     "wpcom-proxy-request": "^2.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
   "babel": {
     "presets": [ "es2015", "stage-2" ]
   },
+  "files": [
+    "build",
+    "History.md",
+    "README.md"
+  ],
   "dependencies": {
     "babel-runtime": "^6.9.2",
     "debug": "^2.2.0",

--- a/test/util.js
+++ b/test/util.js
@@ -1,10 +1,10 @@
 /**
  * Module dependencies
  */
-var wpcomFactory = require( '../' );
-var qs = require( 'qs' );
-var oauthCors = require( 'wpcom-oauth-cors' );
-var fixture = require( './fixture' );
+import wpcomFactory from '../';
+import qs from 'qs';
+import oauthCors from 'wpcom-oauth-cors';
+import fixture from './fixture';
 var configFactory;
 
 try {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,38 +1,19 @@
 module.exports = {
-	entry: __dirname + '/index.js',
+	entry: __dirname + '/build/index.js',
 
 	node: {
 		fs: 'empty'
 	},
 
 	output: {
-		path: __dirname + '/dist',
+		path: __dirname + '/build',
 		filename: 'wpcom.js',
 		libraryTarget: 'var',
 		library: 'WPCOM'
 	},
 
-	module: {
-		loaders: [
-			{
-				test: /\.js$/,
-				exclude: /node_modules/,
-				loader: 'babel-loader',
-				query: {
-					cacheDirectory: true,
-					optional: [ 'runtime' ]
-				}
-			},
-			{
-				test: /\.json$/,
-				exclude: /node_modules/,
-				loader: 'json-loader'
-			}
-		]
-	},
-
 	resolve: {
-		extensions: [ '', '.js', '.json' ]
+		extensions: [ '', '.js' ]
 	},
 
 	devtool: 'sourcemap'


### PR DESCRIPTION
### Building process

Use `ROOT` env var to set sources files to compile. Also I've added `compile` rule to set 8 parallel process in the building process.

```make
compile:
	make build --jobs=8
```

I've restored the `standalone` make rule as well. 

### npm package

Let's publish only the useful files in the npm package:

- index.js
- README.md
- History.md
- lib/

### Tests

The tests files aren't compiled anymore.
To support ES6 with mocha I've added `babel-register` with its presets and thus add the js compilers to mocha command through of `--compilers` parameter.