### PR TITLE
remove `test-all` and add `make-watch` rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@
 THIS_MAKEFILE_PATH:=$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))
 THIS_DIR:=$(shell cd $(dir $(THIS_MAKEFILE_PATH));pwd)
 
-
-ROOT := lib index.js
+ROOT := lib/ index.js
 include $(shell node -e "require('n8-make')")
 
 # BIN directory

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ test:
 	@$(MOCHA) \
 		--timeout 120s \
 		--slow 3s \
+		--grep "$(FILTER)" \
 		--bail \
 		--reporter spec \
 		--compilers js:babel-register \

--- a/Makefile
+++ b/Makefile
@@ -46,20 +46,21 @@ test:
 	@$(MOCHA) \
 		--timeout 120s \
 		--slow 3s \
-		--grep "$(FILTER)" \
 		--bail \
 		--reporter spec \
 		--compilers js:babel-register \
 		test/
 
-test-all:
+test-watch:
 	@$(MOCHA) \
 		--timeout 120s \
 		--slow 3s \
 		--bail \
 		--reporter spec \
 		--compilers js:babel-register \
-		test
+		--watch \
+		--grep "$(FILTER)" \
+		test/
 
 webapp:
 	@$(WEBPACK) -p --config webapp/webpack.config.js

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,9 @@ general:
   branches:
     ignore:
       - gh-pages
+dependencies:
+  pre:
+    - npm install -g npm@3.8.6
 machine:
   node:
-    version: 0.12.7
+    version: 5.11.1

--- a/circle.yml
+++ b/circle.yml
@@ -8,3 +8,6 @@ dependencies:
 machine:
   node:
     version: 5.11.1
+test:
+  override:
+    - DEBUG=wpcom* make test

--- a/test/test.apiVersion.js
+++ b/test/test.apiVersion.js
@@ -1,33 +1,33 @@
+/**
+ * External dependencies
+ */
+import assert from 'assert';
 
 /**
- * Module dependencies
+ * Internal dependencies
  */
-
-var util = require( './util' );
-var assert = require( 'assert' );
+import util from './util';
 
 /**
  * Fixture data
  */
-
-var fixture = require( './fixture' );
+import fixture from './fixture';
 
 /**
- * Create a `Site` instance
+ * Test api versions
  */
-
-describe( 'apiVersion', function() {
+describe( 'apiVersion', () => {
 	// Global instances
-	var wpcom = util.wpcom();
-	var site = wpcom.site( util.site() );
+	const wpcom = util.wpcom();
+	const site = wpcom.site( util.site() );
 
 	it( 'should request changing api version', done => {
-		site.addMediaUrls( { apiVersion: '1.1' }, fixture.media.urls[1] )
+		site.addMediaUrls( { apiVersion: '1.1' }, fixture.media.urls[ 1 ] )
 			.then( data => {
 				assert.ok( data );
 				return site.mediaList( { apiVersion: '1' } )
 			} )
-			.then( () => site.addMediaFiles( { apiVersion: '1.1' }, fixture.media.files[0] ) )
+			.then( () => site.addMediaFiles( { apiVersion: '1.1' }, fixture.media.files[ 0 ] ) )
 			.then( data => {
 				assert.ok( data );
 				done();

--- a/test/test.wpcom.batch.js
+++ b/test/test.wpcom.batch.js
@@ -1,21 +1,21 @@
 /**
  * Module dependencies
  */
-var util = require( './util' );
-var assert = require( 'assert' );
+import util from './util';
+import assert from 'assert';
 
 /**
  * wpcom.batch
  */
 
-describe( 'wpcom.batch', function() {
-	it( 'should makes several data in only one request', function( done ) {
-		var wpcom = util.wpcom();
-		var batch = wpcom.batch();
-		var site = wpcom.site( util.site() );
+describe( 'wpcom.batch', () => {
+	it( 'should makes several data in only one request', done => {
+		const wpcom = util.wpcom();
+		const batch = wpcom.batch();
+		const site = wpcom.site( util.site() );
 
-		var url_site = '/sites/' + site._id;
-		var url_posts = '/sites/' + site._id + '/posts';
+		var url_site = `/sites/${ site._id }`;
+		var url_posts = `/sites/${ site._id }/posts`;
 		var url_me = '/me';
 
 		batch.add( url_site ).add( url_posts ).add( url_me ).run()

--- a/test/test.wpcom.site.settings.js
+++ b/test/test.wpcom.site.settings.js
@@ -1,19 +1,19 @@
 /**
  * Module dependencies
  */
-var util = require( './util' );
-var assert = require( 'assert' );
+import util from './util';
+import assert from 'assert';
 
 /**
  * site.settings
  */
-describe( 'wpcom.site.settings', function() {
+describe( 'wpcom.site.settings', () => {
 	// Global instances
-	var wpcom = util.wpcom();
-	var site = wpcom.site( util.site() );
-	var settings = site.settings();
+	const wpcom = util.wpcom();
+	const site = wpcom.site( util.site() );
+	const settings = site.settings();
 
-	describe( 'wpcom.site.get', function() {
+	describe( 'wpcom.site.get', () => {
 		it( 'should get site settings data', done => {
 			settings.get()
 				.then( data => {


### PR DESCRIPTION
In this PR I've changed slightly the tests rules:

### Run all tests

```bash
> make test
```

### Watch, filter and run tests

```bash
> FILTER=wpcom.site.settings make test-watch
```

**screenshot**
![image](https://cloud.githubusercontent.com/assets/77539/16744226/803cd332-4786-11e6-8ffa-da00f9bbdfce.png)


**video**
https://cloudup.com/csmrGGDNHpB