### PR TITLE
Move bundle file to dist/ folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,12 @@ NPM ?= $(NODE) $(shell which npm)
 MOCHA ?= $(NODE) $(BIN)/mocha
 WEBPACK ?= $(NODE) $(BIN)/webpack
 
-standalone: compile build/wpcom.js
+standalone: compile dist/wpcom.js
 
 compile:
 	make build --jobs=8
 
-build/wpcom.js:
+dist/wpcom.js:
 	@$(WEBPACK) -p --config ./webpack.config.js
 
 install: node_modules

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
 	},
 
 	output: {
-		path: __dirname + '/build',
+		path: __dirname + '/dist',
 		filename: 'wpcom.js',
 		libraryTarget: 'var',
 		library: 'WPCOM'


### PR DESCRIPTION
Let's move the bundle generated with Webpack to `dist/` folder instead of `build/`. 