### PR TITLE
re-export the Classes

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ import Marketing from './lib/marketing';
 import Me from './lib/me';
 import Pinghub from './lib/util/pinghub';
 import Plans from './lib/plans';
-import Req from './lib/util/request';
+import Request from './lib/util/request';
 import Site from './lib/site';
 import Users from './lib/users';
 import sendRequest from './lib/util/send-request';
@@ -182,6 +182,22 @@ WPCOM.prototype.sendRequest = function( params, query, body, fn ) {
 
 	return sendRequest.call( this, params, query, body, fn );
 };
+
+/**
+ * Re-export all the class types.
+ */
+
+WPCOM.Batch = Batch;
+WPCOM.Domain = Domain;
+WPCOM.Domains = Domains;
+WPCOM.Marketing = Marketing;
+WPCOM.Me = Me;
+WPCOM.Pinghub = Pinghub;
+WPCOM.Plans = Plans;
+WPCOM.Request = Request;
+WPCOM.Site = Site;
+WPCOM.Users = Users;
+
 
 if ( ! Promise.prototype.timeout ) {
 	/**

--- a/index.js
+++ b/index.js
@@ -170,7 +170,6 @@ WPCOM.prototype.freshlyPressed = function( query, fn ) {
  * Expose send-request
  * @TODO: use `this.req` instead of this method
  */
-
 WPCOM.prototype.sendRequest = function( params, query, body, fn ) {
 	var msg = 'WARN! Don use `sendRequest() anymore. Use `this.req` method.';
 
@@ -186,7 +185,6 @@ WPCOM.prototype.sendRequest = function( params, query, body, fn ) {
 /**
  * Re-export all the class types.
  */
-
 WPCOM.Batch = Batch;
 WPCOM.Domain = Domain;
 WPCOM.Domains = Domains;

--- a/index.js
+++ b/index.js
@@ -198,7 +198,6 @@ WPCOM.Request = Request;
 WPCOM.Site = Site;
 WPCOM.Users = Users;
 
-
 if ( ! Promise.prototype.timeout ) {
 	/**
 	* Returns a new promise with a deadline

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ export default function WPCOM( token, reqHandler ) {
 	}
 
 	// Add Req instance
-	this.req = new Req( this );
+	this.req = new Request( this );
 
 	// Add Pinghub instance
 	this.pinghub = new Pinghub( this );


### PR DESCRIPTION
For example, so that we can get access to the `Me` constructor
via `import { Me } from 'wpcom'` instead of the current
way of `import Me from 'wpcom/build/lib/me'` which relies on
the implementation details of the `build` and `lib` dirs.