### PR TITLE
Don't mutate query argument in sendRequest

### DIFF
--- a/lib/util/send-request.js
+++ b/lib/util/send-request.js
@@ -45,7 +45,8 @@ export default function sendRequest( params, query, body, fn ) {
 	if ( query.apiVersion ) {
 		params.apiVersion = query.apiVersion;
 		debug( 'apiVersion: %o', params.apiVersion );
-		delete query.apiVersion;
+		// copying object here so we are not mutating original arguments
+		query = Object.assign( {}, query, { apiVersion: undefined } );
 	} else {
 		params.apiVersion = this.apiVersion;
 	}

--- a/lib/util/send-request.js
+++ b/lib/util/send-request.js
@@ -46,7 +46,7 @@ export default function sendRequest( params, query, body, fn ) {
 		params.apiVersion = query.apiVersion;
 		debug( 'apiVersion: %o', params.apiVersion );
 		// copying object here so we are not mutating original arguments
-		query = Object.assign( {}, query, { apiVersion: undefined } );
+		query = { ...query, { apiVersion: undefined } };
 	} else {
 		params.apiVersion = this.apiVersion;
 	}

--- a/lib/util/send-request.js
+++ b/lib/util/send-request.js
@@ -37,16 +37,16 @@ export default function sendRequest( params, query, body, fn ) {
 		body = null;
 	}
 
-	// query could be `null`
-	query = query || {};
+	// query could be `null`. the object is copied so we are not mutating
+	// original arguments in code below
+	query = query ? { ...query } : {};
 
 	// Handle special query parameters
 	// - `apiVersion`
 	if ( query.apiVersion ) {
 		params.apiVersion = query.apiVersion;
 		debug( 'apiVersion: %o', params.apiVersion );
-		// copying object here so we are not mutating original arguments
-		query = { ...query, { apiVersion: undefined } };
+		delete query.apiVersion;
 	} else {
 		params.apiVersion = this.apiVersion;
 	}


### PR DESCRIPTION
I've found a problem with declaring API version in the query argument. I'm using this lib from Calypso and in there, we are tracking what requests are currently being processed (stored in Redux). We identify those requests by a string token consisting of serialized site id and the query.

Example: I'm fetching posts of public post types from site 12345 and I need to override an API version. The serialized token for this request would be `12345:{"type":"public","apiVersion":"1.2"}`. 

Then I pass everything to wpcom.js to fetch me the data and it internally mutates the query argument (`delete query.apiVersion;`), so after successful/failed request when I try to get the serialized request token again to mark it as done, I would get `12345:{"type":"public"}` (no API version) and that wouldn't pair with the original one. 

This PR changes the behavior so we are deleting the `apiVersion` on a copy of the original query. 