### PR TITLE
Improve README for running tests locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,30 @@ config.json file into `test/` folder like bellow:
 
 ```json
 {
-	"site": "<site-id>",
-	"token": "<token>"
+	"development": {
+		"site": "<site-id>",
+		"token": "<token>"
+	},
+	"production": {
+		"site": "<site-id>",
+		"token": "<token>"
+	}
 }
+```
+
+You can get your token using [the example app bundled with `wpcom-oauth`](https://github.com/Automattic/node-wpcom-oauth/tree/master/example) but make sure to edit the example to request the `global` scope (required by some tests).
+
+```diff
+--- a/example/index.js
++++ b/example/index.js
+@@ -30,7 +30,7 @@ app.set('view engine', 'jade');
+ app.get('/', function(req, res){
+   res.render('home', {
+     settings: settings,
+-    url: wpoauth.urlToConnect()
++    url: wpoauth.urlToConnect(undefined, { scope: 'global' })
+   });
+ });
 ```
 
 Run tests:


### PR DESCRIPTION
The README suggested a wrong shape of the config file and silently continued tests that were failing because of missing auth.

I also added a method to easily get a token for tests and pointed out that it needs a special scope. 