### PR TITLE
Send Request: Forward response headers with the response results

### DIFF
--- a/lib/util/send-request.js
+++ b/lib/util/send-request.js
@@ -78,9 +78,9 @@ export default function sendRequest( params, query, body, fn ) {
 	// if callback is provided, behave traditionally
 	if ( 'function' === typeof fn ) {
 		// request method
-		return this.request( params, function( err, res ) {
+		return this.request( params, function( err, res, headers ) {
 			debug_res( res );
-			fn( err, res );
+			fn( err, res, headers );
 		} );
 	}
 


### PR DESCRIPTION
All request handlers used by wpcom.js in calypso ([wpcom-proxy-request](https://github.com/Automattic/wpcom-proxy-request/blob/master/index.js#L144) and [wpcom-xhr-request](https://github.com/Automattic/wpcom-xhr-request/blob/master/index.js#L78)) send a third parameter in their callback: headers.

This PR adds support for that third parameter. This can be used to get access to the [pagination headers](https://developer.wordpress.org/rest-api/using-the-rest-api/pagination/) used by the REST API: `X-WP-Total` and `X-WP-TotalPages`

I didn't update the promise version as it's not needed to [unblock my use case](https://github.com/Automattic/wp-calypso/pull/13828) and would introduce considerable changes (most likely an envelope containing both the headers and the results)

The calypso test suite runs fine (locally) with those changes, I haven't been able to run wpcom.js tests though.

