### PR TITLE
shallow clone query so that it isn't mutated

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ WPCOM.prototype.sendRequest = function( params, query, body, fn ) {
 		console.log( msg );
 	}
 
-	return sendRequest.call( this, params, query, body, fn );
+	return sendRequest.call( this, params, { ...query }, body, fn );
 };
 
 /**


### PR DESCRIPTION
As more heavily covered [here](https://github.com/Automattic/wp-calypso/pull/14393#issuecomment-303561499), wpcom is currently mutating the `query` object it is passed.  This can be confusing for consumers of this library.  

This PR ensures that query is shallow cloned before mutating it.
