### PR TITLE
Allow overriding request http verb in post/put/del

### DIFF
--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -53,8 +53,8 @@ Req.prototype.put = function( params, query, body, fn ) {
 	// params can be a string
 	params = 'string' === typeof params ? { path: params } : params;
 
-	// request method
-	params.method = 'post';
+	// in v1 endpoints, DELETE and PUT operations use http POST, but for v2 endpoints we must allow this to be overridden
+	params.method = params.method || 'post';
 
 	return sendRequest.call( this.wpcom, params, query, body, fn );
 };


### PR DESCRIPTION
For v1 wpcom endpoints, DELETE and PUT operations use http POST with a
special path, but v2 endpoints actually support all native http verbs.
Currently it's possible to override the verb using the `method` argument
in `Req.prototype.get` but not `put`, `post`, and `del`, which hard-code
the verb to POST.

While it would be nice if these methods automatically determined which
system to use, this is a good first step to allow all the methods to
accept the `method` argument and honor it in the same way.