### PR TITLE
Update qs to ^6

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "babel-runtime": "^6.9.2",
     "debug": "^2.2.0",
-    "qs": "^4.0.0",
+    "qs": "^6.5.2",
     "wpcom-xhr-request": "1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/23259 was no problem. Even though this is a two major move, not much changed.