### PR TITLE
Remove the wpcom.me().groups() method and fixup tests

### DIFF
--- a/lib/me.js
+++ b/lib/me.js
@@ -85,17 +85,6 @@ Me.prototype.likes = function( query, fn ) {
 };
 
 /**
- * A list of the current user's group
- *
- * @param {Object} [query] - query object parameter
- * @param {Function} fn - callback function
- * @return {Function} request handler
- */
-Me.prototype.groups = function( query, fn ) {
-	return this.wpcom.req.get( '/me/groups', query, fn );
-};
-
-/**
  * Get current user's connected applications.
  *
  * @param {Object} [query] - query object parameter

--- a/test/test.wpcom.me.js
+++ b/test/test.wpcom.me.js
@@ -61,19 +61,6 @@ describe( 'wpcom.me', function() {
 		} );
 	} );
 
-	describe( 'wpcom.me.groups', function() {
-		it( 'should require groups', done => {
-			me.groups()
-				.then( data => {
-					assert.equal( 'object', typeof data.groups );
-					assert.ok( data.groups instanceof Array );
-
-					done();
-				} )
-				.catch( done );
-		} );
-	} );
-
 	describe( 'wpcom.me.keyringConnections', function() {
 		it( 'should get current user\' keyring connections', done => {
 			me.keyringConnections()

--- a/test/test.wpcom.me.js
+++ b/test/test.wpcom.me.js
@@ -92,7 +92,6 @@ describe( 'wpcom.me', function() {
 			me.postsList()
 				.then( data => {
 					assert.equal( 'number', typeof data.found );
-					assert.equal( 'object', typeof data.meta );
 					assert.ok( data.posts instanceof Array );
 					done();
 				} )

--- a/test/test.wpcom.site.js
+++ b/test/test.wpcom.site.js
@@ -274,8 +274,8 @@ describe( 'wpcom.site', function() {
 
 						assert.equal( 'number', typeof data.monthly_comments );
 						assert.equal( 'number', typeof data.total_comments );
-						assert.equal( 'string', typeof data.most_active_day );
-						assert.equal( 'string', typeof data.most_active_time );
+						assert.ok( 'most_active_day' in data );
+						assert.ok( 'most_active_time' in data );
 						done();
 					} )
 					.catch( done );
@@ -288,7 +288,7 @@ describe( 'wpcom.site', function() {
 					.then( data => {
 						assert.equal( 'string', typeof Date( data.date ) );
 						assert.equal( 'object', typeof data.days );
-						assert.equal( 'object', typeof data['country-info'] );
+						assert.equal( 'object', typeof data[ 'country-info' ] );
 						done();
 					} )
 					.catch( done );


### PR DESCRIPTION
This PR fixes the tests for the library, making them pass for (almost) any testing account.

**Remove the wpcom.me().groups() method**
The endpoint is available only to A12s and not interesting for public. The tests fail when testing with a non-A11n account.

**Fixup the wpcom.me().postsList() test**
Don't check for the `meta` field. It's present only if the posts list has multiple pages of results. Then there is a `meta.next_page` field with URL of the next page. For a testing account with a small number of posts, the `meta` field is not present and the test fails.

**Fixup the wpcom.site().statsComments() test**
For a site with small or zero number of comments, the `most_active_day` and `most_active_time` fields can be `null` rather than date/time strings. Fixup the test to check just presence of the field.

**How to test:**
Acquire an OAuth token for your testing account and then specify the token and the site ID/slug to test on the command line:
```
TOKEN=<token> SITE=<site> make test
```
If the token contains some special characters, quote it so that the shell doesn't try to interpret them.

**How to acquire a OAuth token:**
With your testing account, create an OAuth app at https://developer.wordpress.com/apps

Then use the Client ID and Secret to send a HTTP request to acquire a token:
```
curl -d grant_type=password \
     -d client_id=... \
     -d client_secret=... \
     -d username=... \
     -d password=... \
     https://public-api.wordpress.com/oauth2/token
```
The response is a JSON with an `access_token` field.